### PR TITLE
Fix POD issues.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -60,7 +60,10 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Super-Linter
-        uses: github/super-linter@v4.5.1
+        # Note that this actually uses super-linter version 4.6.0 which is the desired version.
+        # See https://github.com/github/super-linter/issues/1839.
+        # It seems that version 4.6.1 has a bug with perlcritic, so we actually want 4.6.0.
+        uses: github/super-linter@v4.6.1
 
         env:
           VALIDATE_ALL_CODEBASE: false
@@ -73,6 +76,7 @@ jobs:
           CSS_FILE_NAME: .stylelintrc.js
           VALIDATE_TYPESCRIPT_STANDARD: false
           VALIDATE_JAVASCRIPT_STANDARD: false
+          FILTER_REGEX_EXCLUDE: .*/we_b_wor_k3.yml
 
       # This doesn't work and so is disabled.
       # This either should be in a separate workflow or the workflow shoule be renamed.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           HARNESS_PERL_SWITCHES: -MDevel::Cover
         run: |
-          cat conf/webwork3.yml.dist | sed 's/\/opt\/webwork\//\/__w\/webwork3\//g' > conf/webwork3.yml
+          sed 's/\/opt\/webwork\//\/__w\/webwork3\//g' conf/webwork3.dist.yml > conf/webwork3.yml
           perl t/db/build_db.pl
           prove -r t
 

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,3 +1,4 @@
 {
-	"threshold": 5
+	"threshold": 5,
+	"ignore": ["node_modules", "dist"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,12 @@
 {
-  "recommendations": [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "octref.vetur"
-  ],
-  "unwantedRecommendations": [
-    "hookyqr.beautify",
-    "dbaeumer.jshint",
-    "ms-vscode.vscode-typescript-tslint-plugin"
-  ]
+	"recommendations": [
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode",
+		"octref.vetur"
+	],
+	"unwantedRecommendations": [
+		"hookyqr.beautify",
+		"dbaeumer.jshint",
+		"ms-vscode.vscode-typescript-tslint-plugin"
+	]
 }

--- a/lib/DB/Exception.pm
+++ b/lib/DB/Exception.pm
@@ -110,5 +110,4 @@ DB::Exception::InvalidDateField->Trace(1);
 # DB::Exception::PoolNotInCourse->Trace(1);
 DB::Exception::ParametersNeeded->Trace(1);
 
-
 1;

--- a/lib/DB/General.pm
+++ b/lib/DB/General.pm
@@ -2,18 +2,24 @@ package DB::General;
 use strict;
 use warnings;
 
-=pod
-
 =head1 description
 
 The class DB::Schema::ResultSet::General pull the common functionality for
 the other classes in the schema resultsets include
 
+=over
+
 =item Course
+
 =item User
+
 =item ProblemSet
+
 =item UserSet
+
 =item Problem
+
+=back
 
 =cut
 
@@ -30,7 +36,4 @@ use DB::TestUtils qw/removeIDs/;
 use WeBWorK3::Utils::Settings qw/getDefaultCourseSettings mergeCourseSettings
 	getDefaultCourseValues validateCourseSettings/;
 
-
-
-
-
+1;

--- a/lib/DB/Schema/Result/ProblemSet.pm
+++ b/lib/DB/Schema/Result/ProblemSet.pm
@@ -98,7 +98,6 @@ __PACKAGE__->inflate_column(
 	}
 );
 
-=pod
 =head2 set_type
 
 returns the type (HW, Quiz, JITAR, REVIEW) of the problem set

--- a/lib/DB/Schema/Result/ProblemSet/ReviewSet.pm
+++ b/lib/DB/Schema/Result/ProblemSet/ReviewSet.pm
@@ -5,7 +5,6 @@ use warnings;
 
 use Carp;
 
-
 sub valid_dates {
 	return ['open' ,'close'];
 }

--- a/lib/DB/Schema/Result/UserSet.pm
+++ b/lib/DB/Schema/Result/UserSet.pm
@@ -126,10 +126,4 @@ sub required_dates {
 	return $params;
 }
 
-
-
-
-
-
-
 1;

--- a/lib/DB/Schema/Result/UserSet.pm
+++ b/lib/DB/Schema/Result/UserSet.pm
@@ -104,25 +104,33 @@ my $set_type = {
 
 sub valid_params {
 	my $type = shift;
+	## no critic
 	my $params = eval '&' . $set_type->{$type} . '::valid_params';
+	## use critic
 	return $params;
 }
 
 sub required_params {
 	my $type = shift;
+	## no critic
 	my $params = eval '&' . $set_type->{$type} . '::required_params';
+	## use critic
 	return $params;
 }
 
 sub valid_dates {
 	my $type = shift;
+	## no critic
 	my $params = eval '&' . $set_type->{$type} . '::valid_dates';
+	## use critic
 	return $params;
 }
 
 sub required_dates {
 	my $type = shift;
+	## no critic
 	my $params = eval '&' . $set_type->{$type} . '::required_dates';
+	## use critic
 	return $params;
 }
 

--- a/lib/DB/Schema/Result/UserSet/JITAR.pm
+++ b/lib/DB/Schema/Result/UserSet/JITAR.pm
@@ -14,5 +14,4 @@ our @REQUIRED_DATES = @DB::Schema::Result::ProblemSet::JITAR::REQUIRED_DATES;
 our $VALID_PARAMS = $DB::Schema::Result::ProblemSet::JITAR::VALID_PARAMS;
 our $REQUIRED_PARAMS = $DB::Schema::Result::ProblemSet::JITAR::REQUIRED_PARAMS;
 
-
 1;

--- a/lib/DB/Schema/ResultSet/Course.pm
+++ b/lib/DB/Schema/ResultSet/Course.pm
@@ -16,29 +16,24 @@ use DB::TestUtils qw/removeIDs/;
 use WeBWorK3::Utils::Settings qw/getDefaultCourseSettings mergeCourseSettings
 	getDefaultCourseValues validateCourseSettings/;
 
-=pod
-
 =head1 DESCRIPTION
 
 This is the functionality of a Course in WeBWorK.  This package is based on
-<code>DBIx::Class::ResultSet</code>.  The basics are a CRUD for anything on the
+C<DBIx::Class::ResultSet>.  The basics are a CRUD for anything on the
 global courses.
 
-=cut
-
-=pod
 =head2 getCourses
 
-This gets a list of Courses stored in the database in the <code>courses</codes> table.
+This gets a list of Courses stored in the database in the C<courses> table.
 
 =head3 input
 
-<code>$as_result_set</code>, a boolean if the return is to be a result_set
+C<$as_result_set>, a boolean if the return is to be a result_set
 
 =head3 output
 
-An array of courses as a <code>DBIx::Class::ResultSet::Course</code> object
-if <code>$as_result_set</code> is true.  Otherwise an array of hash_ref.
+An array of courses as a C<DBIx::Class::ResultSet::Course> object
+if C<$as_result_set> is true.  Otherwise an array of hash_ref.
 
 =cut
 
@@ -51,20 +46,23 @@ sub getCourses {
 	} @courses;
 }
 
-=pod
 =head1 getCourse
 
-This gets a single course that is stored in the database in the <code>courses</codes> table.
+This gets a single course that is stored in the database in the C<courses> table.
 
 =head3 input
-=item *
-<code>course_info</code>, a hashref containing either course_name or course_id
-=item *
-<code>result_set</code>, a a boolean if the return is to be a result_set
+
+=over
+
+=item * C<course_info>, a hashref containing either course_name or course_id
+
+=item * C<result_set>, a a boolean if the return is to be a result_set
+
+=back
 
 =head3 output
 
-The course either as a <code> DBIx::Class::ResultSet::Course</code> object or a hashref
+The course either as a C< DBIx::Class::ResultSet::Course> object or a hashref
 of the fields.
 
 =cut
@@ -78,18 +76,17 @@ sub getCourse {
 	return { $course->get_inflated_columns };
 }
 
-=pod
 =head1 addCourse
 
-Adds a single course to the database in the <code>courses</codes> table.
+Adds a single course to the database in the C<courses> table.
 
 =head3 input
 
-A set of parameters, especially a <code>course_name</code> of type string.
+A set of parameters, especially a C<course_name> of type string.
 
 =head3 output
 
-The added course as a <code>DBIx::Class::ResultSet::Course</code> object.
+The added course as a C<DBIx::Class::ResultSet::Course> object.
 
 =cut
 
@@ -115,18 +112,17 @@ sub addCourse {
 	return { $new_course->get_inflated_columns };
 }
 
-=pod
 =head1 deleteCourse
 
-This deletes a single course that is stored in the database in the <code>courses</codes> table.
+This deletes a single course that is stored in the database in the C<courses> table.
 
 =head3 input
 
-<code>course_name</code>, a string, the name of the course to be deleted.
+C<course_name>, a string, the name of the course to be deleted.
 
 =head3 output
 
-The deleted course as a <code>DBIx::Class::ResultSet::Course</code> object.
+The deleted course as a C<DBIx::Class::ResultSet::Course> object.
 
 =cut
 
@@ -142,21 +138,23 @@ sub deleteCourse {
 	return { $course_to_delete->get_inflated_columns };
 }
 
-=pod
 =head1 updateCourse
 
-This updates a single course that is stored in the database in the <code>courses</codes> table.
+This updates a single course that is stored in the database in the C<courses> table.
 
 =head3 input
 
-=item *
-<code>course_name</code>, a string
-=item *
-A hash of the course parameters to be updated.
+=over
+
+=item * C<course_name>, a string
+
+=item * A hash of the course parameters to be updated.
+
+=back
 
 =head3 output
 
-The updated course as a <code>DBIx::Class::ResultSet::Course</code> object.
+The updated course as a C<DBIx::Class::ResultSet::Course> object.
 
 =cut
 
@@ -188,22 +186,24 @@ sub updateCourse {
 	return { $course_to_return->get_inflated_columns };
 }
 
-=pod
 =head2 getUserCourses
 
 This gets a list of Courses for a given user
 
 =head3 input
 
-=item*
-hashref containing info about the user
-=item*
-<code>$as_result_set</code>, a boolean if the return is to be a result_set
+=over
+
+=item * hashref containing info about the user
+
+=item * C<$as_result_set>, a boolean if the return is to be a result_set
+
+=back
 
 =head3 output
 
-An array of courses as a <code>DBIx::Class::ResultSet::Course</code> object
-if <code>$as_result_set</code> is true.  Otherwise an array of hash_ref.
+An array of courses as a C<DBIx::Class::ResultSet::Course> object
+if C<$as_result_set> is true.  Otherwise an array of hash_ref.
 
 =cut
 
@@ -220,22 +220,24 @@ sub getUserCourses {
 		@user_courses;
 }
 
-=pod
 =head2 getCourseSettings
 
 This gets the Course Settings for a course
 
 =head3 input
 
-=item*
-hashref containing info about the course
-=item*
-<code>$as_result_set</code>, a boolean if the return is to be a result_set
+=over
+
+=item * hashref containing info about the course
+
+=item * C<$as_result_set>, a boolean if the return is to be a result_set
+
+=back
 
 =head3 output
 
-An array of courses as a <code>DBIx::Class::ResultSet::Course</code> object
-if <code>$as_result_set</code> is true.  Otherwise an array of hash_ref.
+An array of courses as a C<DBIx::Class::ResultSet::Course> object
+if C<$as_result_set> is true.  Otherwise an array of hash_ref.
 
 =cut
 

--- a/lib/DB/Schema/ResultSet/Problem.pm
+++ b/lib/DB/Schema/ResultSet/Problem.pm
@@ -10,29 +10,24 @@ use Data::Dump qw/dd dump/;
 
 use DB::Utils qw/getCourseInfo getSetInfo getProblemInfo/;
 
-=pod
-
 =head1 DESCRIPTION
 
 This is the functionality of a Course in WeBWorK.  This package is based on
-<code>DBIx::Class::ResultSet</code>.  The basics are a CRUD for anything on the
+C<DBIx::Class::ResultSet>.  The basics are a CRUD for anything on the
 global courses.
 
-=cut
-
-=pod
 =head2 getGlobalProblems
 
-This gets a list of all problems stored in the database in the <code>problems</codes> table.
+This gets a list of all problems stored in the database in the C<problems> table.
 
 =head3 input
 
-<code>$as_result_set</code>, a boolean if the return is to be a result_set
+C<$as_result_set>, a boolean if the return is to be a result_set
 
 =head3 output
 
-An array of courses as a <code>DBIx::Class::ResultSet::Course</code> object
-if <code>$as_result_set</code> is true.  Otherwise an array of hash_ref.
+An array of courses as a C<DBIx::Class::ResultSet::Course> object
+if C<$as_result_set> is true.  Otherwise an array of hash_ref.
 
 =cut
 
@@ -51,18 +46,23 @@ sub getGlobalProblems {
 #
 ###
 
-=pod
 =head1 getProblems
 
 This gets all problems in a given course.
 
 =head3 input
 
-=item *
-<code>params</code>, a hashref containing:
-=item -
-<code>course_name</code>, the name of an existing course or
-<code>course_id</code>.
+=over
+
+=item * C<params>, a hashref containing:
+
+=over
+
+=item - C<course_name>, the name of an existing course or C<course_id>.
+
+=back
+
+=back
 
 =head3 notes:
 if either the course or username doesn't exist, an error will be thrown.
@@ -105,8 +105,6 @@ sub getSetProblems {
 	} @problems;
 }
 
-=pod
-
 =head2 getSetProblem
 
 This gets a single problem from a given course and problem
@@ -114,12 +112,16 @@ This gets a single problem from a given course and problem
 =head3 Input
 
 A hashref containing
-=item *
-The course_id or course_name
-=item *
-The set_id or set_name
-=item *
-The problem_id or problem_number
+
+=over
+
+=item * The course_id or course_name
+
+=item * The set_id or set_name
+
+=item * The problem_id or problem_number
+
+=back
 
 =cut
 
@@ -136,19 +138,19 @@ sub getSetProblem {
 	return { $problem->get_inflated_columns };
 }
 
-=pod
-
 =head2 addSetProblem
 
 Add a single problem to an existing problem set within a course
 
-
 =head3 Note
 
-=item *
-If either the problem set or course does not exist an error will be thrown
-=item *
-If the problem parameters are not valid, an error will be thrown.
+=over
+
+=item * If either the problem set or course does not exist an error will be thrown
+
+=item * If the problem parameters are not valid, an error will be thrown.
+
+=back
 
 =cut
 
@@ -164,19 +166,19 @@ sub addSetProblem {
 
 }
 
-=pod
-
 =head2 deleteSetProblem
 
 delete a single problem to an existing problem set within a course
 
-
 =head3 Note
 
-=item *
-If either the problem set or course does not exist an error will be thrown
-=item *
-If the problem parameters are not valid, an error will be thrown.
+=over
+
+=item * If either the problem set or course does not exist an error will be thrown
+
+=item * If the problem parameters are not valid, an error will be thrown.
+
+=back
 
 =cut
 
@@ -199,7 +201,6 @@ sub deleteSetProblem {
 # 	my ( $self, $course_set_info, $new_set_params, $as_result_set ) = @_;
 # }
 
-=pod
 =head2 deleteSetProblem
 
 This deletes the problem with given course and set

--- a/lib/DB/Schema/ResultSet/ProblemPool.pm
+++ b/lib/DB/Schema/ResultSet/ProblemPool.pm
@@ -15,29 +15,24 @@ use Exception::Class (
 	'DB::Exception::PoolProblemNotInPool', 'DB::Exception::ParametersNeeded'
 );
 
-=pod
-
 =head1 DESCRIPTION
 
 This is the functionality of a Course in WeBWorK.  This package is based on
-<code>DBIx::Class::ResultSet</code>.  The basics are a CRUD for anything on the
+C<DBIx::Class::ResultSet>.  The basics are a CRUD for anything on the
 global courses.
 
-=cut
-
-=pod
 =head2 getAllProblemPools
 
-This gets a list of all problems stored in the database in the <code>problem_pool</codes> table.
+This gets a list of all problems stored in the database in the C<problem_pool> table.
 
 =head3 input
 
-<code>$as_result_set</code>, a boolean if the return is to be a result_set
+C<$as_result_set>, a boolean if the return is to be a result_set
 
 =head3 output
 
-An array of courses as a <code>DBIx::Class::ResultSet::Course</code> object
-if <code>$as_result_set</code> is true.  Otherwise an array of hash_ref.
+An array of courses as a C<DBIx::Class::ResultSet::Course> object
+if C<$as_result_set> is true.  Otherwise an array of hash_ref.
 
 =cut
 
@@ -50,7 +45,6 @@ sub getAllProblemPools {
 	} @problem_pools;
 }
 
-=pod
 =head2 getProblemPools
 
 Get all problem pools for a given course
@@ -77,7 +71,6 @@ sub getProblemPools {
 #
 ####
 
-=pod
 =head2 getProblemPool
 
 Get a single problem pool for a given course
@@ -104,7 +97,6 @@ sub getProblemPool {
 
 }
 
-=pod
 =head2 addProblemPool
 
 Add a problem pool for a given course
@@ -139,7 +131,6 @@ sub addProblemPool {
 
 }
 
-=pod
 =head2 updateProblemPool
 
 updates the parameters of an existing problem pool
@@ -165,7 +156,6 @@ sub updateProblemPool {
 	return { $updated_pool->get_columns };
 }
 
-=pod
 =head2 updateProblemPool
 
 updates the parameters of an existing problem pool
@@ -192,21 +182,27 @@ sub deleteProblemPool {
 #
 ####
 
-=pod
 =head2 getPoolProblem
 
 This gets a single problem out of a ProblemPool.
 
 =head3 arguments
 
-=item *
-hashref containing
-=item -
-course_id or course_name
-=item -
-problem_pool_id or pool_name
-=item -
-pool_problem_id or library_id or empty
+=over
+
+=item * hashref containing
+
+=over
+
+=item - course_id or course_name
+
+=item - problem_pool_id or pool_name
+
+=item - pool_problem_id or library_id or empty
+
+=back
+
+=back
 
 =cut
 
@@ -240,7 +236,6 @@ sub getPoolProblem {
 	}
 }
 
-=pod
 =head2 addProblemToPool
 
 This adds a problem as a hashref to an existing problem pool.
@@ -268,22 +263,29 @@ sub addProblemToPool {
 
 }
 
-=pod
 =head2 updatePoolProblem
 
 updated an existing problem to an existing ProblemPool in a course
 
 =head3 arguments
-=item *
-hashref containing
-=item -
-course_id or course_name
-=item -
-pool_name or problem_pool_id
-=item -
-library_id or ???
-=item *
-hashref containing information about the Problem.
+
+=over
+
+=item * hashref containing
+
+=over
+
+=item - course_id or course_name
+
+=item - pool_name or problem_pool_id
+
+=item - library_id or ???
+
+=back
+
+=item * hashref containing information about the Problem.
+
+=back
 
 =cut
 

--- a/lib/DB/Schema/ResultSet/ProblemSet.pm
+++ b/lib/DB/Schema/ResultSet/ProblemSet.pm
@@ -19,18 +19,14 @@ our $SET_TYPES = {
 use DB::Exception;
 use Exception::Class ( "DB::Exception::SetNotInCourse", 'DB::Exception::ParametersNeeded' );
 
-=pod
-
 =head1 DESCRIPTION
 
 This is the functionality of a ProblemSet in WeBWorK.  This package is based on
-<code>DBIx::Class::ResultSet</code>.  The basics are a CRUD for ProblemSets;
-
-=cut
+C<DBIx::Class::ResultSet>.  The basics are a CRUD for ProblemSets;
 
 =head2 getProblemSets
 
-This gets a list of all ProblemSet (and set-like objects) stored in the database in the <code>courses</codes> table.
+This gets a list of all ProblemSet (and set-like objects) stored in the database in the C<courses> table.
 
 =head3 input
 
@@ -38,7 +34,7 @@ none
 
 =head3 output
 
-An array of courses as a <code>DBIx::Class::ResultSet::ProblemSet</code> object.
+An array of courses as a C<DBIx::Class::ResultSet::ProblemSet> object.
 
 =cut
 
@@ -67,11 +63,9 @@ sub getAllProblemSets {
 #
 ####
 
-=pod
 =head2 getProblemSets
 
 Get all problem sets for a given course
-
 
 =cut
 
@@ -86,11 +80,9 @@ sub getProblemSets {
 	return @$sets;
 }
 
-=pod
 =head2 getHWSets
 
 Get all hw sets for a given course
-
 
 =cut
 
@@ -118,11 +110,10 @@ sub getHWSets {
 	my $sets = _formatSets($quizzes);
 	return @$sets;
 }
-=pod
+
 =head2 getQuizzes
 
 Get all quizzes for a given course
-
 
 =cut
 
@@ -138,11 +129,9 @@ sub getQuizzes {
 	} @sets;
 }
 
-=pod
 =head2 getProblemSet
 
 Get one HW set for a given course
-
 
 =cut
 
@@ -168,7 +157,6 @@ sub getProblemSet {
 
 }
 
-=pod
 =head2 addProblemSet
 
 Get one HW set for a given course
@@ -212,11 +200,9 @@ sub addProblemSet {
 	return $set;
 }
 
-=pod
 =head2 updateProblemSet
 
 Update a problem set (HW, Quiz, etc.) for a given course
-
 
 =cut
 
@@ -249,11 +235,9 @@ sub updateProblemSet {
 	return $set;
 }
 
-=pod
 =head2 deleteProblemSet
 
 Delete a problem set (HW, Quiz, etc.) for a given course
-
 
 =cut
 
@@ -278,21 +262,27 @@ sub deleteProblemSet {
 #
 ##
 
-=pod
 =head2 newSetVersion
 
 Creates a new version of a problem set for a given course for either any entire course or a specific user
 
 =head3 inputs
 
-=item *
-A hashref with
-=item -
-course_id or course_name
-=item -
-set_id or set_name
-=item -
-username or user_id (optional)
+=over
+
+=item * A hashref with
+
+=over
+
+=item - course_id or course_name
+
+=item - set_id or set_name
+
+=item - username or user_id (optional)
+
+=back
+
+=back
 
 =head4 output
 
@@ -324,6 +314,5 @@ sub newSetVersion {
 sub _course_rs {
 	return shift->result_source->schema->resultset("Course");
 }
-
 
 1;

--- a/lib/DB/Schema/ResultSet/User.pm
+++ b/lib/DB/Schema/ResultSet/User.pm
@@ -319,7 +319,6 @@ sub getCourseUser {
 #
 ##
 
-=pod
 =head2 addCourseUser
 
 This method adds a course user to the course_users database knowing that there is
@@ -365,7 +364,6 @@ sub addCourseUser {
 	return {$user_to_return->get_inflated_columns};
 }
 
-=pod
 =head2 updateCourseUser
 
 This method updates the course user table
@@ -383,7 +381,6 @@ sub updateCourseUser {
 
 }
 
-=pod
 =head2 deleteCourseUser
 
 This method updates the course user table

--- a/lib/DB/Schema/ResultSet/User.pm
+++ b/lib/DB/Schema/ResultSet/User.pm
@@ -1,10 +1,7 @@
-
-=pod
-
 =head1 DESCRIPTION
 
 This is the functionality of a User in WeBWorK.  This package is based on
-<code>DBIx::Class::ResultSet</code>.  The basics are a CRUD for users.
+C<DBIx::Class::ResultSet>.  The basics are a CRUD for users.
 
 =cut
 
@@ -22,10 +19,9 @@ use DB::Utils qw/getCourseInfo getUserInfo removeLoginParams/;
 use DB::Exception;
 use Exception::Class ( 'DB::Exception::UserNotFound', 'DB::Exception::CourseExists', "DB::Exception::UserNotInCourse" );
 
-=pod
 =head1 getAllGlobalUsers
 
-This gets a list of all users or users stored in the database in the <code>users</codes> table.
+This gets a list of all users or users stored in the database in the C<users> table.
 
 =head3 input
 
@@ -33,7 +29,7 @@ none
 
 =head3 output
 
-An array of courses as a <code>DBIx::Class::ResultSet::Course</code> object.
+An array of courses as a C<DBIx::Class::ResultSet::Course> object.
 
 =cut
 
@@ -44,22 +40,24 @@ sub getAllGlobalUsers {
 	return map { removeLoginParams( { $_->get_inflated_columns } ); } @users;
 }
 
-=pod
 =head1 getGlobalUser
 
-Gets a single user from the <code>users</code> table.
+Gets a single user from the C<users> table.
 
 =head3 input
 
-=item *
-<code>user_info</code>, a hashref of the form <code>{user_id => 1}</code>
-or <code>{username => "username"}</code>.
-=item *
-<code>result_set</code>, a boolean that if true returns the user as a result set.  See below
+=over
+
+=item * C<user_info>, a hashref of the form C<{ user_id => 1 }> or C<{ username => "username" }>.
+
+=item * C<result_set>, a boolean that if true returns the user as a result set.  See below
+
+=back
+
 =head3 output
 
-The user as either a hashref or a  <code>DBIx::Class::ResultSet::User</code> object.  the argument
-<code>result_set</code> determine which is returned.
+The user as either a hashref or a  C<DBIx::Class::ResultSet::User> object.  the argument
+C<result_set> determine which is returned.
 
 =cut
 
@@ -73,23 +71,31 @@ sub getGlobalUser {
 	return removeLoginParams($params);
 }
 
-=pod
 =head1 addGlobalUser
 
-Add a single user to the <code>users</code> table.
+Add a single user to the C<users> table.
 
 =head3 input
 
-<code>params</code>, a hashref including information about the user this includes:
+C<params>, a hashref including information about the user this includes:
+
+=over
+
 =item * username (required)
+
 =item * first_name
+
 =item * last_name
+
 =item * email
+
 =item * student_id
+
+=back
 
 =head3 output
 
-The user as  <code>DBIx::Class::ResultSet::User</code> object or <code>undef</code> if no user exists.
+The user as  C<DBIx::Class::ResultSet::User> object or C<undef> if no user exists.
 
 =cut
 
@@ -107,21 +113,23 @@ sub addGlobalUser {
 	return removeLoginParams( { $new_user->get_columns } );
 }
 
-=pod
 =head1 deleteGlobalUser
 
-This deletes a single user that is stored in the database in the <code>users</codes> table.
+This deletes a single user that is stored in the database in the C<users> table.
 
 =head3 input
 
-=item *
-<code>user_info</code>, a hashref of the form <code>{user_id => 1}</code>
-or <code>{username => "username"}</code>.
-=item *
-as_result_set, a flag to return the result as a ResultSet of a hashref.
+=over
+
+=item * C<user_info>, a hashref of the form C<{user_id => 1}> or C<{username => "username"}>.
+
+=item * as_result_set, a flag to return the result as a ResultSet of a hashref.
+
+=back
+
 =head3 output
 
-The deleted user as a <code>DBIx::Class::ResultSet::User</code> object.
+The deleted user as a C<DBIx::Class::ResultSet::User> object.
 
 =cut
 
@@ -136,27 +144,37 @@ sub deleteGlobalUser {
 	return removeLoginParams( { $deleted_user->get_inflated_columns } );
 }
 
-=pod
 =head1 updateGlobalUser
 
-This updates a single user that is stored in the database in the <code>user</codes> table.
+This updates a single user that is stored in the database in the C<user> table.
 
 =head3 input
 
-=item *
-<code>user_info</code>, a hashref of the form <code>{user_id => 1}</code>
-or <code>{username => "username"}</code>.
-=item *
-<code>params</code>, a hashref of the user parameters.   The following structure is expected:
+=over
+
+=item * C<user_info>, a hashref of the form C<{user_id => 1}> or C<{username => "username"}>.
+
+=item * C<params>, a hashref of the user parameters.   The following structure is expected:
+
+=over
+
 =item - username (required)
+
 =item - first_name
+
 =item - last_name
+
 =item - email
+
 =item - student_id
+
+=back
+
+=back
 
 =head3 output
 
-The updated course as a <code>DBIx::Class::ResultSet::Course</code> or a hashref.
+The updated course as a C<DBIx::Class::ResultSet::Course> or a hashref.
 
 =cut
 
@@ -187,19 +205,21 @@ sub authenticate {
 #
 ####
 
-=pod
 =head1 getUsers
 
 This gets all users in a given course.
 
 =head3 input
 
-=item *
-<code>course_name</code>, a string
+=over
+
+=item * C<course_name>, a string
+
+=back
 
 =head3 output
 
-An array of Users (as hashrefs) or an arrayref of <code>DBIx::Class::ResultSet::User</code>
+An array of Users (as hashrefs) or an arrayref of C<DBIx::Class::ResultSet::User>
 
 =cut
 
@@ -226,19 +246,25 @@ sub getCourseUsers {
 #
 ###
 
-=pod
 =head1 getUser
 
 This gets a single user in a given course.
 
 =head3 input
 
-=item *
-<code>params</code>, a hashref containing:
-=item -
-<code>course_name</code>, the name of an existing course
-=item -
-<code>username</code>, the username of an existing user.
+=over
+
+=item * C<params>, a hashref containing:
+
+=over
+
+=item - C<course_name>, the name of an existing course
+
+=item - C<username>, the username of an existing user.
+
+=back
+
+=back
 
 =head3 notes:
 if either the course or username doesn't exist, an error will be thrown.
@@ -263,8 +289,6 @@ sub getUser {
 	return removeLoginParams($user_params);
 }
 
-
-
 sub getCourseUser {
 	my ( $self, $course_user_info, $as_result_set ) = @_;
 
@@ -276,8 +300,6 @@ sub getCourseUser {
 	DB::Exception::TooManyParameters->throw(
 		message => "Too many parameters were passed into getCourseUser"
 	) if (scalar(@keys) != 2 );
-
-
 
 	my $course_user = $self->result_source->schema->resultset("CourseUser")
 		->find({course_id => $course->course_id, user_id => $user->user_id});
@@ -307,7 +329,6 @@ The method returns only the information in the course_user table
 
 =cut
 
-
 sub addCourseUser {
 	my ( $self, $course_user_params, $as_result_set ) = @_;
 	# warn "in addCourseUser";
@@ -329,7 +350,6 @@ sub addCourseUser {
 	for my $key (qw/ course_id course_name username user_id/) {
 		delete $params->{$key};
 	}
-
 
 	## still need to check params for validity.
 
@@ -385,46 +405,51 @@ sub deleteCourseUser {
 #
 ###
 
-
-
-=pod
 =head1 addUser
 
 This adds a User to an existing course
 
 =head3 input
 
-=item *
-<code>course_info</code> containing either course_name or course_id as a hashref.
+=over
 
-=item *
-<code>params</code>, a hashref containing
-=item -
-<code>username</code>, the username of a user (required)
-=item -
-<code>first_name</code>, the first name of the user
-=item -
-<code>last_name</code>, the last name of the user
-=item -
-<code>student_id</code>, the student id of the user
-=item -
-<code>roles</code>, A listing of roles of the user (instructor, student)
+=item * C<course_info> containing either course_name or course_id as a hashref.
+
+=item * C<params>, a hashref containing
+
+=over
+
+=item - C<username>, the username of a user (required)
+
+=item - C<first_name>, the first name of the user
+
+=item - C<last_name>, the last name of the user
+
+=item - C<student_id>, the student id of the user
+
+=item - C<roles>, A listing of roles of the user (instructor, student)
+
+=back
+
+=back
 
 =head3 notes
-=item *
-If both the username and course name is not included, an error will be thrown.
-=item *
-If the course doesn't exist, an error will be thrown
-=item *
-If the user's username already exists as a global user, an error will be thrown.
 
+=over
+
+=item * If both the username and course name is not included, an error will be thrown.
+
+=item * If the course doesn't exist, an error will be thrown
+
+=item * If the user's username already exists as a global user, an error will be thrown.
+
+=back
 
 =head3 output
 
 An hashref of the added user.
 
 =cut
-
 
 # sub addUser {
 # 	my ( $self, $course_info, $params, $as_result_set ) = @_;
@@ -481,34 +506,43 @@ sub _checkCourseUser {
 	return 1;
 }
 
-=pod
 =head2 updateUser
 
 This updates a User in an existing course
 
 =head3 input
 
-=item *
-<code>course_info</code> containing either course_name or course_id as a hashref.
-=item *
-<code>params</code>, a hashref containing
-=item -
-<code>username</code>, the username of a user (required)
-=item -
-<code>first_name</code>, the first name of the user
-=item -
-<code>last_name</code>, the last name of the user
-=item -
-<code>student_id</code>, the student id of the user
-=item -
-<code>roles</code>, A listing of roles of the user (instructor, student)
+=over
+
+=item * C<course_info> containing either course_name or course_id as a hashref.
+
+=item * C<params>, a hashref containing
+
+=over
+
+=item - C<username>, the username of a user (required)
+
+=item - C<first_name>, the first name of the user
+
+=item - C<last_name>, the last name of the user
+
+=item - C<student_id>, the student id of the user
+
+=item - C<roles>, A listing of roles of the user (instructor, student)
+
+=back
+
+=back
 
 =head3 notes
-=item *
-If the course doesn't exist, an error will be thrown
-=item *
-If the username field is not defined, an error will be thrown.
 
+=over
+
+=item * If the course doesn't exist, an error will be thrown
+
+=item * If the username field is not defined, an error will be thrown.
+
+=back
 
 =head3 output
 
@@ -539,28 +573,37 @@ An hashref of the added user.
 # 	return removeLoginParams( { $user->get_columns, %$course_user_to_return } );
 # }
 
-=pod
 =head2 deleteUser
 
 This deletes a User in an existing course.  This doesn't remove the global user however.
 
 =head3 input
 
-=item *
-<code>course_info</code> containing either course_name or course_id as a hashref.
-=item *
-<code>user_params</code>, a hashref containing either
-=item -
-<code>username</code>, the username of a user
-=item -
-<code>user_id</code>, user_id of the user
+=over
+
+=item * C<course_info> containing either course_name or course_id as a hashref.
+
+=item * C<user_params>, a hashref containing either
+
+=over
+
+=item - C<username>, the username of a user
+
+=item - C<user_id>, user_id of the user
+
+=back
+
+=back
 
 =head3 notes
-=item *
-If the course doesn't exist, an error will be thrown
-=item *
-If the username field is not defined, an error will be thrown.
 
+=over
+
+=item * If the course doesn't exist, an error will be thrown
+
+=item * If the username field is not defined, an error will be thrown.
+
+=back
 
 =head3 output
 
@@ -595,6 +638,5 @@ An hashref of the added user.
 # 	return removeLoginParams( { $user->get_columns, $deleted_course_user->get_inflated_columns } );
 
 # }
-
 
 1;

--- a/lib/DB/Schema/ResultSet/UserSet.pm
+++ b/lib/DB/Schema/ResultSet/UserSet.pm
@@ -1,9 +1,7 @@
-=pod
-
 =head1 DESCRIPTION
 
 This is the functionality of a UserSet in WeBWorK.  This package is based on
-<code>DBIx::Class::ResultSet</code>.  The basics are a CRUD for user sets.
+C<DBIx::Class::ResultSet>.  The basics are a CRUD for user sets.
 
 =cut
 
@@ -21,18 +19,25 @@ use DB::WithParams;
 
 use Exception::Class ( 'DB::Exception::UserSetExists' );
 
-=pod
 =head2 getUserSets
 
 get all UserSet for a given course and either a given user or given set
 
 =head3 input
-=item *
-A hashref containing
-=item -
-Either a course_name or course_id
-=item -
-information on either a set (set_name or set_id) or a user (user_id or username)
+
+=over
+
+=item * A hashref containing
+
+=over
+
+=item - Either a course_name or course_id
+
+=item - information on either a set (set_name or set_id) or a user (user_id or username)
+
+=back
+
+=back
 
 =cut
 
@@ -60,7 +65,6 @@ sub getUserSetsForUser {
 
 }
 
-=pod
 =head2 getUserSetsForSet
 
 get an array of all user sets for a given problem set (HW, quiz, etc.)
@@ -94,9 +98,6 @@ sub getUserSetsForSet {
 	return @user_sets_to_return;
 }
 
-
-
-=pod
 =head2 getUserSet
 
 get a single UserSet for a given course, user, and ProblemSet
@@ -121,9 +122,6 @@ sub getUserSet {
 	return _mergeUserSet($problem_set,$user_set,$user);
 }
 
-
-
-=pod
 =head2 addUserSet
 
 add a single UserSet for a given course, user, and ProblemSet
@@ -166,7 +164,6 @@ sub addUserSet {
 	return _mergeUserSet($problem_set,$s,$user);
 }
 
-=pod
 =head2 updateUserSet
 
 update a single UserSet for a given course, user, and ProblemSet
@@ -205,13 +202,10 @@ sub updateUserSet {
 		## update not getting all values, so get the user_set
 	my $s = $self->find({user_set_id => $user_set->user_set_id});
 
-
 	return $updated_user_set if $as_result_set;
 	return _mergeUserSet($problem_set,$s,$user);
 }
 
-
-=pod
 =head2 deleteUserSet
 
 delete a single UserSet for a given course, user, and ProblemSet
@@ -229,14 +223,12 @@ sub deleteUserSet {
 		username => $user_set_info->{username}
 	) unless defined($user_set);
 
-
 	my $problem_set = $self->_getProblemSet($user_set_info);
 	my $user = $self->_getUser($user_set_info);
 
 	$user_set->delete;
 	return $user_set if $as_result_set;
 	return _mergeUserSet($problem_set,$user_set,$user);
-
 
 }
 
@@ -274,7 +266,6 @@ sub _getUser {
 	return $self->_user_rs->getUser($user_info,1);
 }
 
-
 # return the course/set info given the user_set_info is passed in
 
 sub _getCourse {
@@ -308,7 +299,6 @@ sub _mergeUserSet {
 		username => $user->username
 	};
 }
-
 
 
 1;

--- a/lib/DB/TestUtils.pm
+++ b/lib/DB/TestUtils.pm
@@ -11,17 +11,11 @@ require Exporter;
 use base qw(Exporter);
 our @EXPORT_OK = qw/buildHash loadCSV removeIDs filterBySetType loadSchema/;
 
-
-=pod
-
 =head1 DESCRIPTION
 
 This is a collection of utilities for testing purposes
 
-=cut
-
-=pod
-=head2 buildParamHash
+=head2 buildHash
 
 This takes a hashref and builds up a params field and a dates field for any
 field starting with PARAM: and DATE: respectively.
@@ -55,8 +49,6 @@ sub loadCSV {
 	return @all_items;
 }
 
-=pod
-
 =head2 removeIDs
 
 Removes all of the fields of an arrayref that ends in _id
@@ -72,7 +64,6 @@ sub removeIDs {  # remove any field that ends in _id except student_id
 	}
 	return;
 }
-
 
 sub filterBySetType {
 	my ($all_sets,$type,$course_name) = @_;

--- a/lib/DB/Utils.pm
+++ b/lib/DB/Utils.pm
@@ -2,7 +2,6 @@ package DB::Utils;
 use warnings;
 use strict;
 
-
 require Exporter;
 use base qw(Exporter);
 our @EXPORT_OK = qw/getCourseInfo getUserInfo getSetInfo updateAllFields
@@ -64,8 +63,6 @@ sub _get_info {
 	return $output_info;
 }
 
-=pod
-
 =head1 updateAllFields
 
 This method updates the fields of the first argument with any from the second argument.
@@ -88,14 +85,12 @@ sub updateAllFields {
 	return $fields_to_return;
 }
 
-=pod
 =head2 removeLoginParams
 
 This removes the login_params field from a user.  There is no reason the login_params are needed
 off the server.
 
 =cut
-
 
 sub removeLoginParams {
 	my $params = shift;

--- a/lib/WeBWorK3.pm
+++ b/lib/WeBWorK3.pm
@@ -77,7 +77,6 @@ sub confDirectory {
 	return "$webwork_root/conf";
 }
 
-
 sub load_account {
 	my ($self,$user_id)  = @_;
 	my $user = $self->schema->resultset("User")->getGlobalUser({username => $user_id});
@@ -155,6 +154,5 @@ sub settingsRoutes {
 	$self->routes->get('/webwork3/api/courses/:course_id/settings')->to("Settings#getCourseSettings");
 	return;
 }
-
 
 1;

--- a/lib/WeBWorK3/Controller/ProblemSet.pm
+++ b/lib/WeBWorK3/Controller/ProblemSet.pm
@@ -13,7 +13,6 @@ use Data::Dumper;
 
 my $log = Mojo::Log->new;
 
-
 sub getAllProblemSets {
 	my $self = shift;
 	my @all_problem_sets =  $self->schema->resultset("ProblemSet")->getAllProblemSets;
@@ -76,6 +75,5 @@ sub deleteProblemSet {
 	$self->render(json => $problem_set);
 	return;
 }
-
 
 1;

--- a/lib/WeBWorK3/Controller/Settings.pm
+++ b/lib/WeBWorK3/Controller/Settings.pm
@@ -2,10 +2,9 @@ package WeBWorK3::Controller::Settings;
 use warnings;
 use strict;
 
-=pod
 =head1 Description
 
-These are the method that call the database for course settings
+These are the methods that call the database for course settings
 
 =cut
 

--- a/lib/WeBWorK3/Utils/Settings.pm
+++ b/lib/WeBWorK3/Utils/Settings.pm
@@ -158,14 +158,21 @@ sub kebobCase {
 	return shift =~ /^[a-z][a-z_\d]*[a-z\d]$/;
 }
 
-=pod
+=head1 validateSettingsConfig
 
 This checks the configuration for a single setting is valid.  This includes
 
+=over
+
 =item Check that the variable name is kebob case
+
 =item Ensure that all fields passed in are valid
+
 =item Ensure that all require fields are present
+
 =item Checks that the default value is appropriate for the type
+
+=back
 
 =cut
 

--- a/lib/WeBWorK3/Utils/Settings.pm
+++ b/lib/WeBWorK3/Utils/Settings.pm
@@ -19,16 +19,12 @@ use DB::Exception::InvalidCourseFieldType;
 
 use WeBWorK3;
 
-
 my @allowed_fields = qw/var category subcategory doc doc2 default type options/;
 my @required_fields = qw/var doc type default/;
 
-
-=pod
 =head1 loadDefaultCourseSettings
 
 load the default settings from the conf/course_settings.yaml file
-
 
 =cut
 
@@ -38,7 +34,6 @@ sub getDefaultCourseSettings {
 
 my @course_setting_categories = qw/email optional general permissions problem problem_set/;
 
-=pod
 =head1 getDefaultCourseValues
 
 getDefaultCourseValues returns the values of all default course values and returns
@@ -60,7 +55,6 @@ sub getDefaultCourseValues {
 	return $all_settings;
 }
 
-=pod
 =head1 mergeCourseSettings
 
 mergeCourseSettings takes in two settings and merges them in the following way:
@@ -70,7 +64,6 @@ For each course setting in the first argument (typically from the configuration 
 2. use the value from the first argument
 
 =cut
-
 
 sub mergeCourseSettings {
 	my ($settings,$settings_to_update) = @_;
@@ -105,14 +98,17 @@ sub validateSettingsConfFile {
 	return 1;
 }
 
-
-
 =pod
 
 isValidCourseSettings checks if the course settings are valid including
+
+=over
+
 =item the key is defined in the course setting configuration file
+
 =item the value is appropriate for the given setting.
 
+=back
 
 =cut
 
@@ -131,7 +127,6 @@ sub flattenCourseSettings {
 	}
 	return \@flattened_settings;
 }
-
 
 sub validateCourseSettings {
 	my $course_settings = flattenCourseSettings(shift);
@@ -241,7 +236,6 @@ sub validateList {
 	my $setting = shift;
 	croak "The options field for the type list in " . $setting->{var} . " is missing " unless defined($setting->{options});
 	croak "The options field for " . $setting->{var} . " is not an ARRAYREF" unless ref($setting->{options}) eq "ARRAY";
-
 
 	# see if the $setting->{options} is an arrayref of strings or hashrefs
 	my @opt = (ref($setting->{options}->[0]) eq "HASH") ?

--- a/t/db/004_course_users.t
+++ b/t/db/004_course_users.t
@@ -304,5 +304,4 @@ SKIP: {
 
 }
 
-
 done_testing;


### PR DESCRIPTION
HTML does not work in POD. So you can't use `<code>...</code>` tags.
Instead use `C<...>`.

Command paragraphs (`=headN`, `=item`, `=cut`, etc.) should always have an empty line before and after them.

Command paragraphs automatically begin POD, so there is no need to have `=pod` before `=headN`. In fact `=pod` is just a basic command paragraph that begins a basic unformatted section. Furthermore, using `=pod` immediately followed by something like `=head1` with no empty line between is an error.

`=item`'s need to be wrapped in `=over` and `=back`. Furthermore, items at different levels need an additional over and back. So `=item -` nested inside an `=item *` needs another over and back.