### PR TITLE
Fix the database code to work with mysql or mariadb.

### DIFF
--- a/conf/webwork3.dist.yml
+++ b/conf/webwork3.dist.yml
@@ -3,15 +3,18 @@ secrets:
   - 3cdf63327fcf77deaed1d200df4b9fee66af2326
 webwork3_home: /opt/webwork/webwork3
 
-# if ignore_permissions is set to true, all routes can be executed
-# this should only be used in development
+# If ignore_permissions is set to true, all routes can be executed.
+# This should only be used in development.
 ignore_permissions: true
 
-# sqlite database
-sqlite_dsn: dbi:SQLite:/opt/webwork/webwork3/t/db/sample_db.sqlite
-# mysql or mariadb setup
-mariadb_dsn: dbi:mysql:test_webwork3:localhost:3306
+# Database settings
+
+# For the sqlite database
+database_dsn: dbi:SQLite:/opt/webwork/webwork3/t/db/sample_db.sqlite
+# For mysql or mariadb
+#database_dsn: dbi:mysql:dbname=webwork3
+
+# Database credentials for mysql or mariadb.
+# These are ignored if the 'sqlite' database is used.
 database_user: webworkWrite
 database_password: password
-# determine which database to use
-database: sqlite

--- a/docker/webwork3.dockerfile
+++ b/docker/webwork3.dockerfile
@@ -8,40 +8,40 @@ ENV HARNESS_PERL_SWITCHES -MDevel::Cover
 RUN apt-get update && \
 	apt-get install -qy --no-install-recommends --no-install-suggests \
 		build-essential=12.8ubuntu1 \
-		# mariadb-server=1:10.3.30-0ubuntu0.20.04.1 # if desired to use a full database
-		# autoconf=2.69-11.1 \
-		# libtool=2.4.6-14 \
 		ca-certificates=20210119~20.04.1 \
 		cpanminus=1.7044-1 \
-		libssl-dev=1.1.1f-1ubuntu2.5 \
-		openssl=1.1.1f-1ubuntu2.5 \
-		libtest-harness-perl=3.42-2 \
-		libdata-dump-perl=1.23-1 \
-		liblist-moreutils-perl=0.416-1build5 \
-		libtest-exception-perl=0.43-1 \
-		libtry-tiny-perl=0.30-1 \
-		libexception-class-perl=1.44-1 \
-		libdbix-dbschema-perl=0.45-1 \
-		libdbd-sqlite3-perl=1.64-1build1 \
-		libtext-csv-perl=2.00-1 \
-		libjson-perl=4.02000-2 \
-		libdbd-mysql-perl=4.050-3 \
-		libnet-ssleay-perl=1.88-2ubuntu1 \
+		git=1:2.25.1-1ubuntu3.1 \
+		libarray-utils-perl=0.5-1 \
+		libclone-perl=0.43-2 \
 		libcrypt-ssleay-perl=0.73.06-1build3 \
+		libdata-dump-perl=1.23-1 \
+		libdatetime-format-strptime-perl=1.7600-1 \
+		libdbd-mysql-perl=4.050-3 \
+		libdbd-sqlite3-perl=1.64-1build1 \
+		libdbix-class-perl=0.082841-1 \
+		libdbix-class-inflatecolumn-serializer-perl=0.09-1 \
+		libdbix-dbschema-perl=0.45-1 \
 		libdevel-cover-perl=1.33-1build1 \
-		git=1:2.25.1-1ubuntu3.1 && \
+		libexception-class-perl=1.44-1 \
+		libjson-perl=4.02000-2 \
+		liblist-moreutils-perl=0.416-1build5 \
+		libnet-ssleay-perl=1.88-2ubuntu1 \
+		libsql-translator-perl=1.60-1 \
+		libssl-dev=1.1.1f-1ubuntu2.5 \
+		libtest-exception-perl=0.43-1 \
+		libtest-harness-perl=3.42-2 \
+		libtext-csv-perl=2.00-1 \
+		libtry-tiny-perl=0.30-1 \
+		libyaml-libyaml-perl=0.81+repack-1 \
+		# mariadb-server=1:10.3.31-0ubuntu0.20.04.1 \ # if desired to use a full database
+		openssl=1.1.1f-1ubuntu2.5 && \
 	rm -rf /var/lib/apt/lists/* && \
-	cpanm --notest Array::Utils \
-		DBIx::Class \
+	cpanm --notest \
 		DBIx::Class::DynamicSubclass \
-		DateTime::Format::Strptime \
 		Mojolicious \
 		Mojolicious::Plugin::NotYAMLConfig \
 		Mojolicious::Plugin::DBIC \
 		Mojolicious::Plugin::Authentication \
-		Devel::Cover::Report::Codecov \
-		YAML::XS \
-		Clone \
-		SQL::Translator
+		Devel::Cover::Report::Codecov
 
 ENTRYPOINT ["/bin/bash"]

--- a/lib/DB/Schema/Result/Course.pm
+++ b/lib/DB/Schema/Result/Course.pm
@@ -3,14 +3,14 @@ use base qw/DBIx::Class::Core/;
 use strict;
 use warnings;
 
-use JSON;
-
 our @VALID_DATES     = qw/open end/;
 our @REQUIRED_DATES  = qw//;
 our $VALID_PARAMS    = { visible => q{[01]} };
 our $REQUIRED_PARAMS = { _ALL_   => ['visible'] };
 
 __PACKAGE__->table('course');
+
+__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
 
 __PACKAGE__->add_columns(
 	course_id => {
@@ -29,6 +29,8 @@ __PACKAGE__->add_columns(
 		size          => 256,
 		is_nullable   => 0,
 		default_value => "{}",
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
 	},
 	visible => {
 		data_type     => 'boolean',
@@ -51,16 +53,5 @@ __PACKAGE__->has_many( problem_pools => 'DB::Schema::Result::ProblemPool', 'cour
 
 # set up the one-to-one relationship to course settings;
 __PACKAGE__->has_one( course_settings => 'DB::Schema::Result::CourseSettings', 'course_id' );
-
-__PACKAGE__->inflate_column(
-	"course_dates",
-	{   inflate => sub {
-			decode_json shift;
-		},
-		deflate => sub {
-			encode_json shift;
-		}
-	}
-);
 
 1;

--- a/lib/DB/Schema/Result/CourseSettings.pm
+++ b/lib/DB/Schema/Result/CourseSettings.pm
@@ -3,8 +3,6 @@ use base qw/DBIx::Class::Core/;
 use strict;
 use warnings;
 
-use JSON;
-
 our @VALID_DATES    = qw/open end/;
 our @REQUIRED_DATES = qw//;
 our $VALID          = {
@@ -14,6 +12,8 @@ our $VALID          = {
 our $REQUIRED = { _ALL_ => ['visible'] };
 
 __PACKAGE__->table('course_settings');
+
+__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
 
 __PACKAGE__->add_columns(
 	course_settings_id => {
@@ -32,54 +32,53 @@ __PACKAGE__->add_columns(
 		size          => 256,
 		is_nullable   => 0,
 		default_value => "{}",
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
 	},
 	optional => {
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
 		default_value => "{}",
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
 	},
 	problem_set => {
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
 		default_value => "{}",
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
 	},
 	problem => {
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
 		default_value => "{}",
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
 	},
 	permissions => {
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
 		default_value => "{}",
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
 	},
 	email => {
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
 		default_value => "{}",
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
 	}
 );
 
 __PACKAGE__->set_primary_key('course_settings_id');
 
 __PACKAGE__->belongs_to( course => 'DB::Schema::Result::Course', 'course_id' );
-
-for my $column (qw/general optional problem_set problem permissions email/) {
-	__PACKAGE__->inflate_column(
-		"$column",
-		{   inflate => sub {
-				decode_json shift;
-			},
-			deflate => sub {
-				encode_json shift;
-			}
-		}
-	);
-}
 
 1;

--- a/lib/DB/Schema/Result/CourseUser.pm
+++ b/lib/DB/Schema/Result/CourseUser.pm
@@ -2,9 +2,10 @@ package DB::Schema::Result::CourseUser;
 use base qw/DBIx::Class::Core/;
 use strict;
 use warnings;
-use JSON;
 
 __PACKAGE__->table('course_user');
+
+__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
 
 our $VALID_PARAMS = {
 	comment        => q{.*},
@@ -51,13 +52,14 @@ __PACKAGE__->add_columns(
 		size        => 16,
 		is_nullable => 1,
 	},
-	params =>    # store params as a JSON object
-		{
+	params => { # store params as a JSON object
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
-		default_value => '{}'
-		}
+		default_value => '{}',
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
+	}
 );
 
 __PACKAGE__->set_primary_key('course_user_id');
@@ -70,18 +72,5 @@ __PACKAGE__->has_many( user_sets => 'DB::Schema::Result::UserSet', 'user_id' );
 
 # __PACKAGE__->belongs_to( user_id => 'DB::Schema::Result::User' );
 # __PACKAGE__->belongs_to( course_id => 'DB::Schema::Result::Course' );
-
-### Handle the params column using JSON.
-
-__PACKAGE__->inflate_column(
-	'params',
-	{   inflate => sub {
-			decode_json shift;
-		},
-		deflate => sub {
-			encode_json shift;
-		}
-	}
-);
 
 1;

--- a/lib/DB/Schema/Result/ProblemPool.pm
+++ b/lib/DB/Schema/Result/ProblemPool.pm
@@ -18,7 +18,7 @@ __PACKAGE__->add_columns(
 		is_nullable => 0,
 	},
 	pool_name => {
-		data_type   => 'text',
+		data_type   => 'varchar',
 		size        => 256,
 		is_nullable => 0,
 	}

--- a/lib/DB/Schema/Result/ProblemSet.pm
+++ b/lib/DB/Schema/Result/ProblemSet.pm
@@ -3,13 +3,10 @@ use base qw/DBIx::Class::Core/;
 
 use strict;
 use warnings;
-use Data::Dump qw/dd/;
-use JSON;
-use Carp;
-
-__PACKAGE__->load_components(qw/DynamicSubclass Core/);
 
 __PACKAGE__->table('problem_set');
+
+__PACKAGE__->load_components(qw/DynamicSubclass Core/, qw/InflateColumn::Serializer Core/);
 
 __PACKAGE__->add_columns(
 	set_id => {
@@ -19,7 +16,7 @@ __PACKAGE__->add_columns(
 		is_auto_increment => 1,
 	},
 	set_name => {
-		data_type   => 'text',
+		data_type   => 'varchar',
 		size        => 256,
 		is_nullable => 0,
 	},
@@ -38,20 +35,22 @@ __PACKAGE__->add_columns(
 		default_value => 1,
 		is_nullable   => 0
 	},
-	dates =>    # store dates as a JSON object
-		{
+	dates => { # store dates as a JSON object
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
-		default_value => '{}'
-		},
-	params =>    # store params as a JSON object
-		{
+		default_value => '{}',
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
+	},
+	params => { # store params as a JSON object
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
-		default_value => '{}'
-		}
+		default_value => '{}',
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
+	}
 );
 
 #
@@ -73,30 +72,6 @@ __PACKAGE__->add_unique_constraint( [qw/course_id set_name/] );
 __PACKAGE__->belongs_to( courses => 'DB::Schema::Result::Course', 'course_id' );
 __PACKAGE__->has_many( problems  => 'DB::Schema::Result::Problem', 'set_id' );
 __PACKAGE__->has_many( user_sets => 'DB::Schema::Result::UserSet', 'set_id' );
-
-### Handle the params column using JSON.
-
-__PACKAGE__->inflate_column(
-	'params',
-	{   inflate => sub {
-			decode_json shift;
-		},
-		deflate => sub {
-			encode_json shift;
-		}
-	}
-);
-
-__PACKAGE__->inflate_column(
-	'dates',
-	{   inflate => sub {
-			decode_json shift;
-		},
-		deflate => sub {
-			encode_json shift;
-		}
-	}
-);
 
 =head2 set_type
 

--- a/lib/DB/Schema/Result/User.pm
+++ b/lib/DB/Schema/Result/User.pm
@@ -3,9 +3,9 @@ use base qw/DBIx::Class::Core/;
 use strict;
 use warnings;
 
-use JSON;
-
 __PACKAGE__->table('user');
+
+__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
 
 __PACKAGE__->add_columns(
 	user_id => {
@@ -15,7 +15,7 @@ __PACKAGE__->add_columns(
 		is_auto_increment => 1,
 	},
 	username => {
-		data_type   => 'text',
+		data_type   => 'varchar',
 		size        => 256,
 		is_nullable => 0,
 	},
@@ -44,7 +44,9 @@ __PACKAGE__->add_columns(
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
-		default_value => "{}"
+		default_value => '{}',
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
 	}
 );
 
@@ -54,15 +56,4 @@ __PACKAGE__->add_unique_constraint( [qw/username/] );
 __PACKAGE__->has_many( course_users => 'DB::Schema::Result::CourseUser', { 'foreign.user_id' => 'self.user_id' } );
 __PACKAGE__->many_to_many( courses => 'course_users', 'courses' );
 
-__PACKAGE__->inflate_column(
-	'login_params',
-	{
-		inflate => sub {
-			decode_json shift;
-		},
-		deflate => sub {
-			encode_json shift;
-		}
-	}
-);
 1;

--- a/lib/DB/Schema/Result/UserProblem.pm
+++ b/lib/DB/Schema/Result/UserProblem.pm
@@ -3,8 +3,6 @@ use base qw/DBIx::Class::Core/;
 use strict;
 use warnings;
 
-use JSON;
-
 ### this is the table that stores problems for a given Problem Set
 
 ## Note: we probably also need to store the problem info if it changes.
@@ -14,6 +12,8 @@ use JSON;
 # don't allow the same problem/seed.
 
 __PACKAGE__->table('user_problem');
+
+__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
 
 __PACKAGE__->add_columns(
 	user_problem_id => {
@@ -52,7 +52,9 @@ __PACKAGE__->add_columns(
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
-		default_value => '{}'
+		default_value => '{}',
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
 	}
 );
 
@@ -60,16 +62,5 @@ __PACKAGE__->set_primary_key('user_problem_id');
 
 __PACKAGE__->belongs_to( problems     => 'DB::Schema::Result::Problem',    'problem_id' );
 __PACKAGE__->belongs_to( course_users => 'DB::Schema::Result::CourseUser', 'user_id' );
-
-__PACKAGE__->inflate_column(
-	'params',
-	{   inflate => sub {
-			decode_json shift;
-		},
-		deflate => sub {
-			encode_json shift;
-		}
-	}
-);
 
 1;

--- a/lib/DB/Schema/Result/UserSet.pm
+++ b/lib/DB/Schema/Result/UserSet.pm
@@ -3,11 +3,9 @@ use base qw(DBIx::Class::Core DB::WithParams DB::WithDates);
 use strict;
 use warnings;
 
-use JSON;
-
-# __PACKAGE__->load_components(qw/DynamicSubclass Core/);
-
 __PACKAGE__->table('user_set');
+
+__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
 
 __PACKAGE__->add_columns(
 	user_set_id => {
@@ -32,20 +30,22 @@ __PACKAGE__->add_columns(
 		is_nullable   => 0,
 		default_value => 1,
 	},
-	dates =>    # store dates as a JSON object
-		{
+	dates => { # store dates as a JSON object
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
-		default_value => '{}'
-		},
-	params =>    # store params as a JSON object
-		{
+		default_value => '{}',
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
+	},
+	params => { # store params as a JSON object
 		data_type     => 'text',
 		size          => 256,
 		is_nullable   => 0,
-		default_value => '{}'
-		}
+		default_value => '{}',
+		serializer_class => 'JSON',
+		serializer_options => { utf8 => 1 }
+	}
 );
 
 __PACKAGE__->set_primary_key('user_set_id');
@@ -68,30 +68,6 @@ __PACKAGE__->belongs_to( problem_sets => 'DB::Schema::Result::ProblemSet', 'set_
 # 		4 => 'DB::Schema::Result::UserSet::ReviewSet',
 # 	}
 # );
-
-### Handle the params column using JSON.
-
-__PACKAGE__->inflate_column(
-	'params',
-	{   inflate => sub {
-			decode_json shift;
-		},
-		deflate => sub {
-			encode_json shift;
-		}
-	}
-);
-
-__PACKAGE__->inflate_column(
-	'dates',
-	{   inflate => sub {
-			decode_json shift;
-		},
-		deflate => sub {
-			encode_json shift;
-		}
-	}
-);
 
 use Data::Dump qw/dd/;
 

--- a/lib/DB/TestUtils.pm
+++ b/lib/DB/TestUtils.pm
@@ -85,16 +85,8 @@ sub loadSchema {
 
 	my $config = LoadFile("$main::lib_dir/../conf/webwork3.yml");
 
-	my $schema;
-	# load the database
-	if ($config->{database} eq 'sqlite') {
-		$schema  = DB::Schema->connect($config->{sqlite_dsn});
-	} elsif ($config->{database} eq 'mariadb') {
-		$schema  = DB::Schema->connect($config->{mariadb_dsn},$config->{database_user},$config->{database_password});
-	}
-
-	return $schema;
-
+	# Load the database
+	return DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 }
 
 1;

--- a/lib/WeBWorK3.pm
+++ b/lib/WeBWorK3.pm
@@ -29,19 +29,10 @@ sub startup {
 
 	# Configure the application
 	$self->secrets($config->{secrets});
-	## get the dbix plugin loaded
 
-	# load some configuration for the database:
-
-	my $schema;
-	# load the database
-	if ($config->{database} eq 'sqlite') {
-		$schema  = DB::Schema->connect($config->{sqlite_dsn});
-	} elsif ($config->{database} eq 'mariadb') {
-		$schema  = DB::Schema->connect($config->{mariadb_dsn},$config->{database_user},$config->{database_password});
-	}
-
-	$self->plugin('DBIC',{schema => $schema});
+	# Load the database and DBIC plugin
+	my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
+	$self->plugin('DBIC', { schema => $schema });
 
 	# load the authentication plugin
 	$self->plugin(

--- a/t/db/build_db.pl
+++ b/t/db/build_db.pl
@@ -3,6 +3,7 @@
 #
 # this file builds a sqlite database file based on a csv file
 #
+
 use warnings;
 use strict;
 
@@ -18,7 +19,6 @@ use lib "$main::lib_dir";
 use Text::CSV qw/csv/;
 use Data::Dump qw/dd/;
 use Carp;
-use JSON;
 use feature "say";
 use DateTime::Format::Strptime;
 use YAML::XS qw/LoadFile/;
@@ -35,19 +35,11 @@ my $verbose = 1;
 
 my $config = LoadFile("$main::lib_dir/../conf/webwork3.yml");
 
-my $schema;
-my $dsn;
 # load the database
-if ($config->{database} eq 'sqlite') {
-	$dsn = $config->{sqlite_dsn};
-	$schema  = DB::Schema->connect($dsn);
-} elsif ($config->{database} eq 'mariadb') {
-	$dsn = $config->{mariadb_dsn};
-	$schema  = DB::Schema->connect($dsn,$config->{database_user},$config->{database_password});
-}
+my $schema  = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
-say "restoring the database with dbi: $dsn" if $verbose;
-say $dsn;
+say "restoring the database with dbi: $config->{database_dsn}" if $verbose;
+
 $schema->deploy({ add_drop_table => 1 });  ## create the database based on the schema
 
 


### PR DESCRIPTION
Fix the database to work with an actual database management system like mysql or mariadb.  There were two problems that made the database code fail with those systems.  First, columns of type text can not be part of a primary key or index.  So those columns were switched to varchar type.  Second, the JSON columns were not correctly coded.  That could have been
fixed, but the DBIx::Class::InflateColumn::Serializer::JSON package handles this nicely, so that was used.  On Ubuntu you can install the package libdbix-class-inflatecolumn-serializer-perl.

Also restrucure the database settings in the webwork3.dist.yml file a bit.  There is no need to distinguish the cases for sqlite, mariadb, or mysql, and so a `database` config variable is not needed.  Just set the `database_dsn`.  The `database_user` and `database_password` variables are ignored if sqlite is used.

Also, the build_db.pl file was made executable for convenience.

Note that the docker image (drgrice1/webwork3) used by the unit test workflow has been updated for these changes.  The updated docker/webwork3.dockerfile file that was used for this build is included in this pull request.