### PR TITLE
Fix typscript unhandled diagnostic issue

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -14,7 +14,6 @@ module.exports = {
 		'no-invalid-position-at-import-rule': null,
 		'selector-pseudo-class-no-unknown': [true, {
 			ignorePseudoClasses: ['deep', 'v-deep']
-		}],
-
+		}]
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,6 @@
 	"extends": "@quasar/app/tsconfig-preset.json",
 	"compilerOptions": {
 		"baseUrl": "."
-	}
+	},
+	"exclude": ["dist", ".quasar", "node_modules"]
 }


### PR DESCRIPTION
Fix the typescript unhandled diagnostic that occurs when the quasar dev server is run while the dist folder from the build is present.  This is caused by an incorrect exclusion in the @quasar/app/tsconfig-preset.json file.  In that file the directory is excluded as "/dist".  The forward slash does not work here.  So the exclusion is overridden in our tsconfig.json file.

This is the issue that @pstaabp saw when testing @drdrew42's no-iframe pull request.  I had of course already seen that, but hadn't found the fix yet.  Here it is!