### PR TITLE
Add missing chunk names

### DIFF
--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -7,7 +7,7 @@ const routes: RouteRecordRaw[] = [
 	},
 	{
 		path: '/',
-		component: () => import('src/layouts/MainLayout.vue'),
+		component: () => import(/* webpackChunkName: "MainLayout" */ 'src/layouts/MainLayout.vue'),
 		children: [
 			{
 				path: 'welcome',
@@ -177,7 +177,7 @@ const routes: RouteRecordRaw[] = [
 	},
 	{
 		path: '/:catchAll(.*)*',
-		component: () => import('pages/Error404.vue')
+		component: () => import(/* webpackChunkName: "Error404" */ 'pages/Error404.vue')
 	}
 ];
 


### PR DESCRIPTION
Add a couple of missing chunk names so that the production build doesn't have chunks like `595.88eda779.js`.

Just a minor issue that has been bugging me for the production build.