### PR TITLE
Update the build and deployment method for apache2 on Ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ pnpm-debug.log*
 # Project files
 sample_db.sqlite
 conf/webwork3.yml
+conf/apache2/webwork3-apache2.conf
+conf/apache2/webwork3.service
+conf/apache2/renderer.service
 
 # Devel::Cover
 cover_db/

--- a/README.md
+++ b/README.md
@@ -109,45 +109,62 @@ This section builds all of the UI code using webpack and fires up a browser wind
 4. You should get a "Login to WeBWorK" screen.  You can use the Lisa Simpson account with the username `lisa` and the
    password `lisa`.
 
-### Production build and deployment (instructions for apache2 on Ubuntu2)
+### Production build and deployment (instructions for apache2 on Ubuntu)
 
 TODO: add instructions for other servers and operating systems and add a docker deployment approach
 
 1. Inside the `webwork3` directory, execute `yarn install` or `npm install`.
 
-2. Build the client side user interface with `quasar build`.
+2. Build the client side user interface with `quasar build` or `npm run build`.
 
 3. Copy `webwork3/dist/spa` to `/var/www/html/webwork3` (or create a link).
 
-4. Add the following lines to your apache2 site configuration file:
+4. Copy `conf/apache2/webwork3-apache2.dist.conf` to `conf/apache2/webwork3-apache2.conf`, and create a link to that
+   file in `/etc/apache2/conf-enabled`.  This can be accomplished by executing the following commands from the webwork3
+   directory.
 
-```apacheconf
-# Vue Router configuration for webwork3
-<IfModule mod_rewrite.c>
-    <Directory "/var/www/html/webwork3">
-    RewriteEngine On
-    RewriteBase /webwork3/
-    RewriteRule ^webwork3/index\.html$ - [L]
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule . /webwork3/index.html [L]
-    </Directory>
-</IfModule>
-# Mojolicious configuration for webwork3
-<Proxy /webwork3/api/*>
-    Require all granted
-</Proxy>
-ProxyRequests Off
-ProxyPreserveHost On
-ProxyPass /webwork3/api http://localhost:8080/webwork3/api keepalive=On
-ProxyPassReverse /webwork3/api http://localhost:8080/webwork3/api
-ProxyPass /webwork3/api/* http://localhost:8080/webwork3/api/ keepalive=On
-ProxyPassReverse /webwork3/api/* http://localhost:8080/webwork3/api/
-RequestHeader set X-Forwarded-Proto "http"
+```sh
+cp conf/apache2/webwork3-apache2.dist.conf conf/apache2/webwork3-apache2.conf
+sudo ln -s $(pwd)/conf/apache2/webwork3-apache2.conf /etc/apache2/conf-enabled
 ```
 
-4. Restart apache2 with `sudo systemctl restart apache2` (or the appropriate command for your system).
+5. Restart apache2 with `sudo systemctl restart apache2`.
 
-5. Run `hypnotoad bin/webwork3` from within the `webwork3` directory.
+6. Set up permissions for the api with the following commands executed from the webwork3 directory.
 
-6. Visit `localhost/webwork3`.
+```sh
+sudo chown -R youruser:www-data logs
+sudo chmod g+rw logs/*
+```
+
+7. Copy `conf/apache2/webwork3.dist.service` to `conf/apache2/webwork3.service` and modify `WorkingDirectory` with the
+   correct path to the webwork3 location.  Make sure to uncomment the hypnotoad `pid_file` setting in the `webwork3.yml`
+   file.  Then enable and start the webwork3 api service by executing the following from within the `webwork3`
+   directory.
+
+```sh
+sudo systemctl enable $(pwd)/conf/apache2/webwork3.service
+sudo systemctl start webwork3
+```
+
+8. Set up permissions for the renderer with the following commands executed from the renderer directory.
+
+```sh
+sudo chown -R youruser:www-data logs 
+sudo chmod g+rw logs/standalone_results.log
+sudo chmod -R g+rw lib/WeBWorK/tmp/* lib/WeBWorK/htdocs/tmp/*
+```
+
+9. Copy `conf/apache2/renderer.dist.service` to `conf/apache2/renderer.service` and modify `WorkingDirectory` in the
+   copied file with the correct path to the webwork3 location.  Add `pid_file => '/var/run/webwork3/renderer.pid'` and
+   `proxy => 1` to the hypnotoad configuration in the `render_app.conf` file.  Then enable and start the renderer
+   service by executing the following from within the `webwork3` directory.
+
+```sh
+sudo systemctl enable $(pwd)/conf/apache2/renderer.service
+sudo systemctl start renderer
+```
+
+   Note that anytime the server is rebooted the webwork3 api and renderer services will be automatically started.
+
+10. Visit `localhost/webwork3`.

--- a/conf/apache2/renderer.dist.service
+++ b/conf/apache2/renderer.dist.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Standalone Renderer for WeBWorK 3
+After=network.target
+
+[Service]
+Type=forking
+User=www-data
+Group=www-data
+PIDFile=/var/run/webwork3/renderer.pid
+PermissionsStartOnly=true
+ExecStartPre=-/bin/mkdir /var/run/webwork3
+ExecStartPre=/bin/chown -R www-data:www-data /var/run/webwork3
+# Change /path/to to the full path to the renderer directory.
+WorkingDirectory=/path/to/renderer
+ExecStart=/usr/local/bin/hypnotoad script/render_app
+ExecReload=/usr/local/bin/hypnotoad script/render_app
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target
+
+# vim: syntax=systemd

--- a/conf/apache2/webwork3-apache2.dist.conf
+++ b/conf/apache2/webwork3-apache2.dist.conf
@@ -1,0 +1,38 @@
+# Vue router client ui configuration
+<IfModule mod_rewrite.c>
+	# Note that this must be consistent with the value of publicPath in quasar.conf.js.
+	<Directory "/var/www/html/webwork3">
+	RewriteEngine On
+	RewriteBase /webwork3/
+	RewriteRule ^/webwork3/index\.html$ - [L]
+	RewriteCond %{REQUEST_FILENAME} !-f
+	RewriteCond %{REQUEST_FILENAME} !-d
+	RewriteRule . /webwork3/index.html [L]
+	</Directory>
+</IfModule>
+
+# Server side api configuration
+<Proxy /webwork3/api/*>
+	Require all granted
+</Proxy>
+ProxyRequests Off
+ProxyPreserveHost On
+ProxyPass /webwork3/api http://localhost:3000/webwork3/api keepalive=On
+ProxyPassReverse /webwork3/api http://localhost:3000/webwork3/api
+ProxyPass /webwork3/api/* http://localhost:3000/webwork3/api/ keepalive=On
+ProxyPassReverse /webwork3/api/* http://localhost:3000/webwork3/api/
+RequestHeader set X-Forwarded-Proto "http"
+
+# renderer configuration
+<Proxy /renderer/*>
+	Require all granted
+</Proxy>
+ProxyRequests Off
+ProxyPreserveHost On
+ProxyPass /renderer http://localhost:3001/renderer keepalive=On
+ProxyPassReverse /renderer http://localhost:3001/renderer
+ProxyPass /renderer/* http://localhost:3001/renderer/ keepalive=On
+ProxyPassReverse /renderer/* http://localhost:3001/renderer/
+RequestHeader set X-Forwarded-Proto "http"
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/conf/apache2/webwork3.dist.service
+++ b/conf/apache2/webwork3.dist.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=WeBWorK 3
+After=network.target
+
+[Service]
+Type=forking
+User=www-data
+Group=www-data
+PIDFile=/var/run/webwork3/webwork3.pid
+PermissionsStartOnly=true
+ExecStartPre=-/bin/mkdir /var/run/webwork3
+ExecStartPre=/bin/chown -R www-data:www-data /var/run/webwork3
+# Change /path/to to the full path to the webwork3 directory.
+ExecStart=/usr/local/bin/hypnotoad /path/to/webwork3/bin/webwork3
+ExecReload=/usr/local/bin/hypnotoad /path/to/webwork3/bin/webwork3
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target
+
+# vim: syntax=systemd

--- a/conf/webwork3.dist.yml
+++ b/conf/webwork3.dist.yml
@@ -23,3 +23,19 @@ database_password: password
 cookie_samesite: "None"
 cookie_secure: true
 cookie_lifetime: 3600
+
+# Production server configuration
+hypnotoad:
+  listen:
+    - http://*:3000
+  accepts: 400
+  workers: 10
+  spare: 5
+  clients: 100
+  graceful_timeout: 45
+  inactivity_timeout: 30
+  keep_alive_timeout: 30
+  requests: 5
+  # Uncomment the next two lines for the apache2 production setup
+  #pid_file: /var/run/webwork3/webwork3.pid
+  #proxy: 1


### PR DESCRIPTION
This adds an apache2 conf file instead of suggesting that the user copy and paste the configuration into the site configuration file.

Also add systemctl service files to run the webwork3 api and the renderer.

The README.md file is updated with instructions on how to use this setup.