### PR TITLE
redirect log levels to console.warn and console.error

### DIFF
--- a/src/boot/logger.ts
+++ b/src/boot/logger.ts
@@ -24,6 +24,7 @@ const logger = winston.createLogger({
 // If we're not in production then log to the console
 if (process.env.NODE_ENV !== 'production') {
 	logger.add(new winston.transports.Console({
+		level: 'debug',
 		stderrLevels: ['error'],
 		consoleWarnLevels: ['warn', 'debug'],
 		format: winston.format.printf((info) => {return `[${info.level}] ${info.message}`;}),

--- a/src/boot/logger.ts
+++ b/src/boot/logger.ts
@@ -2,20 +2,6 @@ import { boot } from 'quasar/wrappers';
 import winston from 'winston';
 import 'setimmediate';
 
-const consoleFormat = winston.format.combine(
-	winston.format.simple(),
-	winston.format.printf(msg =>
-		winston.format.colorize().colorize(msg.level, `[${msg.level}] ${msg.message}`)
-	)
-);
-
-winston.addColors({
-	debug: 'magenta',
-	info: 'cyan',
-	warn: 'yellow',
-	error: 'red',
-});
-
 const logger = winston.createLogger({
 	level: 'debug',
 	format: winston.format.simple(),
@@ -38,7 +24,9 @@ const logger = winston.createLogger({
 // If we're not in production then log to the console
 if (process.env.NODE_ENV !== 'production') {
 	logger.add(new winston.transports.Console({
-		format: consoleFormat,
+		stderrLevels: ['error'],
+		consoleWarnLevels: ['warn', 'debug'],
+		format: winston.format.printf((info) => {return `[${info.level}] ${info.message}`;}),
 		handleExceptions: true
 	}));
 }


### PR DESCRIPTION
Forget about colorizing console logs, and swap in the use of console.warn and console.error
We have the added benefit of getting stack traces that way as well...

* logger.error => console.error
* logger.warn => console.warn
* logger.debug => console.warn