### PR TITLE
Clean up of the unit tests and the related workflow.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,8 +17,6 @@ jobs:
         env:
           HARNESS_PERL_SWITCHES: -MDevel::Cover
         run: |
-          cp conf/webwork3.dist.yml conf/webwork3.yml
-          cp conf/ww3-dev.dist.yml conf/ww3-dev.yml
           perl t/db/build_db.pl
           prove -r t
 

--- a/t/db/001_courses.t
+++ b/t/db/001_courses.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
-#
+
 # This tests the basic database CRUD functions with courses.
-#
+
 use warnings;
 use strict;
 
@@ -25,51 +25,41 @@ use DB::Schema;
 
 use DB::TestUtils qw/loadCSV removeIDs loadSchema/;
 
-# load some configuration for the database:
-
+# Load the database
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
-
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = LoadFile($config_file);
-
-my $schema =
-	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
-
-# $schema->storage->debug(1);  # print out the SQL commands.
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $course_rs = $schema->resultset("Course");
 
-## get a list of courses from the CSV file
-
+# Get a list of courses from the CSV file.
 my @courses = loadCSV("$main::ww3_dir/t/db/sample_data/courses.csv");
 for my $course (@courses) {
 	delete $course->{course_params};
 }
 @courses = sortByCourseName(\@courses);
 
-## check the list of all courses
+# Check the list of all courses
 my @courses_from_db = $course_rs->getCourses;
 for my $course (@courses_from_db) { removeIDs($course); }
 @courses_from_db = sortByCourseName(\@courses_from_db);
 
 is_deeply(\@courses_from_db, \@courses, "getCourses: course names");
 
-## get a single course by name
-
+# Get a single course by name
 my $course  = $course_rs->getCourse({ course_name => "Calculus" });
 my $calc_id = $course->{course_id};
 delete $course->{course_id};
 my @calc_courses = grep { $_->{course_name} eq "Calculus" } @courses;
 is_deeply($course, $calc_courses[0], "getCourse: get a single course by name");
 
-## get a single course by course_id
-
+# Get a single course by course_id
 $course = $course_rs->getCourse({ course_id => $calc_id });
 delete $course->{course_id};
 is_deeply($course, $calc_courses[0], "getCourse: get a single course by id");
 
-## try to get a single course with sending proper info:
+# Try to get a single course by sending proper info:
 throws_ok {
 	$course_rs->getCourse({ course_id => $calc_id, course_name => "Calculus" });
 }
@@ -80,14 +70,13 @@ throws_ok {
 }
 "DB::Exception::ParametersNeeded", "getCourse: sends wrong info";
 
-## try to get a single course that doesn't exist
-
+# Try to get a single course that doesn't exist
 throws_ok {
 	$course_rs->getCourse({ course_name => "non_existent_course" });
 }
 "DB::Exception::CourseNotFound", "getCourse: get a non-existent course";
 
-## add a course
+# Add a course
 my $new_course_params = {
 	course_name  => "Geometry",
 	visible      => 1,
@@ -100,15 +89,13 @@ removeIDs($new_course);
 
 is_deeply($new_course_params, $new_course, "addCourse: add a new course");
 
-## add a course that already exists
-
+# Add a course that already exists
 throws_ok {
 	$course_rs->addCourse({ course_name => "Geometry", visible => 1 });
 }
 "DB::Exception::CourseExists", "addCourse: course already exists";
 
-## update the course name
-
+# Update the course name
 my $updated_course = $course_rs->updateCourse({ course_id => $added_course_id }, { course_name => "Geometry II" });
 
 $new_course_params->{course_name} = "Geometry II";
@@ -116,8 +103,7 @@ delete $updated_course->{course_id};
 
 is_deeply($new_course_params, $updated_course, "updateCourse: update a course by name");
 
-## Try to update an non-existent course
-
+# Try to update an non-existent course
 throws_ok {
 	$course_rs->updateCourse({ course_name => "non_existent_course" });
 }
@@ -128,26 +114,25 @@ throws_ok {
 }
 "DB::Exception::CourseNotFound", "updateCourse: update a non-existent course_id";
 
-## delete a course
+# Delete a course
 my $deleted_course = $course_rs->deleteCourse({ course_name => "Geometry II" });
 removeIDs($deleted_course);
 
 is_deeply($new_course_params, $deleted_course, "deleteCourse: delete a course");
 
-## try to delete a non-existent course by name
+# Try to delete a non-existent course by name
 throws_ok {
 	$course_rs->deleteCourse({ course_name => "undefined_name" })
 }
 "DB::Exception::CourseNotFound", "deleteCourse: delete a non-existent course_name";
 
-## try to delete a non-existent course by id
+# Try to delete a non-existent course by id
 throws_ok {
 	$course_rs->deleteCourse({ course_id => -9 })
 }
 "DB::Exception::CourseNotFound", "deleteCourse: delete a non-existent course_id";
 
-## get a list of courses for a user
-
+# Get a list of courses for a user
 my @user_courses = $course_rs->getUserCourses({ username => "lisa" });
 for my $user_course (@user_courses) {
 	removeIDs($user_course);
@@ -165,8 +150,7 @@ for my $user_course (@user_courses_from_csv) {
 
 is_deeply(\@user_courses, \@user_courses_from_csv, "getUserCourses: get all courses for a given user");
 
-## try to get a list of course from a non-existent user
-
+# Try to get a list of course from a non-existent user
 throws_ok {
 	$course_rs->getUserCourses({ username => "non_existent_user" });
 }

--- a/t/db/002_course_settings.t
+++ b/t/db/002_course_settings.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
-#
+
 # This tests the basic database CRUD functions with course settings.
-#
+
 use warnings;
 use strict;
 
@@ -13,16 +13,10 @@ BEGIN {
 
 use lib "$main::ww3_dir/lib";
 
-use Data::Dumper;
-use List::MoreUtils qw(uniq);
-
 use Test::More;
 use Test::Exception;
-use Try::Tiny;
 use YAML::XS qw/LoadFile/;
 
-use DB::WithParams;
-use DB::WithDates;
 use DB::Schema;
 
 use WeBWorK3::Utils::Settings qw/getDefaultCourseSettings getDefaultCourseValues
@@ -31,18 +25,13 @@ use WeBWorK3::Utils::Settings qw/getDefaultCourseSettings getDefaultCourseValues
 
 use DB::TestUtils qw/loadCSV removeIDs loadSchema/;
 
+# Load the database
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
-
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = LoadFile($config_file);
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
-my $schema =
-	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
-
-# $schema->storage->debug(1);  # print out the SQL commands.
-
-# test for various types
+# Test for various types
 
 ok(isInteger(0),     "check type: integer");
 ok(isInteger(100),   "check type: integer");
@@ -82,16 +71,14 @@ ok(isDecimal("00.33"),  "check type: decimal");
 ok(!isDecimal("0-.33"), "check type: not a decimal");
 ok(!isDecimal("abc"),   "check type: not a decimal");
 
-## check that the configuration file is valid;
-
+# Check that the configuration file is valid.
 is(validateSettingsConfFile(), 1, "configuration file valid");
 
-### TODO: test to make sure that all of the checks for the course configurations work.
+# TODO: Test to make sure that all of the checks for the course configurations work.
 
 my $default_course_settings = getDefaultCourseSettings();
 
-# check that each of the given course_setting types are both valid and invalid
-
+# Check that each of the given course_setting types are both valid and invalid.
 my $valid_setting = {
 	var      => "my_setting",
 	doc      => "this is a setting",
@@ -99,10 +86,9 @@ my $valid_setting = {
 	category => "general",
 	default  => 0
 };
-
 is(validateSettingConfig($valid_setting), 1, "course setting: valid setting");
 
-## check various parts of the setting;
+# Check various parts of the setting.
 
 throws_ok {
 	validateSettingConfig({
@@ -147,7 +133,7 @@ throws_ok {
 }
 "DB::Exception::InvalidCourseFieldType", "course setting: non valid course parameter type";
 
-## validate settings
+# Validate settings
 
 throws_ok {
 	validateSettingConfig({
@@ -195,10 +181,9 @@ throws_ok {
 
 my $course_rs = $schema->resultset("Course");
 
-# check that the default settings are working
+# Check that the default settings are working
 
-#make a new course with no settings and compare to the default settings
-
+# Make a new course with no settings and compare to the default settings
 my $new_course = $course_rs->addCourse({ course_name => "New Course" });
 
 my $default_course_values = getDefaultCourseValues();
@@ -207,75 +192,55 @@ my $course_settings       = $course_rs->getCourseSettings($new_course_info);
 
 is_deeply($course_settings, $default_course_values, "course settings: default course_settings");
 
-# set a single course setting in General
-
+# Set a single course setting in General
 my $updated_general_setting = { general => { course_description => "This is my new course description" } };
-
 my $updated_course_settings = $course_rs->updateCourseSettings($new_course_info, $updated_general_setting);
-
-my $current_course_values = mergeCourseSettings($default_course_values, $updated_general_setting);
-
+my $current_course_values   = mergeCourseSettings($default_course_values, $updated_general_setting);
 is_deeply($current_course_values, $updated_course_settings, "course_settings: updated general setting");
 
-# update another general setting
-
+# Update another general setting
 $updated_general_setting = { general => { hardcopy_theme => "One Column" } };
-
 $updated_course_settings = $course_rs->updateCourseSettings($new_course_info, $updated_general_setting);
-
-$current_course_values = mergeCourseSettings($current_course_values, $updated_general_setting);
-
+$current_course_values   = mergeCourseSettings($current_course_values, $updated_general_setting);
 is_deeply($current_course_values, $updated_course_settings, "course_settings: updated another general setting");
 
-# set a single course setting in Optional Modules
-
+# Set a single course setting in Optional Modules.
 my $updated_optional_setting = { optional => { enable_show_me_another => 1 } };
 $updated_course_settings = $course_rs->updateCourseSettings($new_course_info, $updated_optional_setting);
 $current_course_values   = mergeCourseSettings($current_course_values, $updated_optional_setting);
-
 is_deeply($current_course_values, $updated_course_settings, "course_settings: updated optional setting");
 
-# set a single course setting in problem_set
-
+# Set a single course setting in problem_set.
 my $updated_problem_set_setting = { problem_set => { time_assign_due => "11:52" } };
 $updated_course_settings = $course_rs->updateCourseSettings($new_course_info, $updated_problem_set_setting);
 $current_course_values   = mergeCourseSettings($current_course_values, $updated_problem_set_setting);
-
 is_deeply($current_course_values, $updated_course_settings, "course_settings: updated problem set setting");
 
-# set a single course setting in problem
-
+# Set a single course setting in problem.
 my $updated_problem_setting = { problem => { display_mode => "images" } };
 $updated_course_settings = $course_rs->updateCourseSettings($new_course_info, $updated_problem_setting);
 $current_course_values   = mergeCourseSettings($current_course_values, $updated_problem_setting);
-
 is_deeply($current_course_values, $updated_course_settings, "course_settings: updated problem setting");
 
-# make sure that an nonexistant setting throws an exception
-
+# Make sure that an nonexistant setting throws an exception.
 my $undefined_problem_setting = { general => { non_existent_setting => 1 } };
-
 throws_ok {
 	$course_rs->updateCourseSettings($new_course_info, $undefined_problem_setting);
 }
 "DB::Exception::UndefinedCourseField", "course settings: undefined course_setting field";
 
-# make sure that an invalid list option setting throws an exception
-
+# Make sure that an invalid list option setting throws an exception.
 my $invalid_list_option = { general => { hardcopy_theme => 'default' } };
-
 $course_rs->updateCourseSettings($new_course_info, $invalid_list_option);
 
-# make sure that an invalid integer setting throws an exception
+# TODO: Make sure that an invalid integer setting throws an exception
 
-# make sure that an invalid email list setting throws an exception
+# TODO: Make sure that an invalid email list setting throws an exception
 
-# load the default settings:
+# Load the default settings
+#my $course_defaults = checkSettings("$main::webwork_home/conf/course_defaults.yml");
 
-# my $course_defaults = checkSettings("$main::webwork_home/conf/course_defaults.yml");
-
-## finally delete the new course that was made;
-
+# Finally delete the new course that was made;
 $course_rs->deleteCourse({ course_id => $new_course->{course_id} });
 
 done_testing();

--- a/t/db/003_users.t
+++ b/t/db/003_users.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
-#
+
 # This tests the basic database CRUD functions with courses.
-#
+
 use warnings;
 use strict;
 
@@ -13,47 +13,31 @@ BEGIN {
 
 use lib "$main::ww3_dir/lib";
 
-use Text::CSV qw/csv/;
-use Data::Dumper;
 use Test::More;
 use Test::Exception;
-use Try::Tiny;
-use Carp;
 
-use DB::WithParams;
-use DB::WithDates;
 use DB::Schema;
-use DB::TestUtils qw/loadCSV removeIDs loadSchema/;
+use DB::TestUtils qw/loadCSV removeIDs/;
 use YAML qw/LoadFile/;
 
-my $config;
+# Load the database
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-if (-e $config_file) {
-	$config = LoadFile($config_file);
-} else {
-	die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?";
-}
-
-my $schema =
-	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
-
-# $schema->storage->debug(1);  # print out the SQL commands.
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
+my $config = LoadFile($config_file);
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $users_rs = $schema->resultset("User");
 
-# remove the maggie user if exists in the database
+# Remove the user "maggie" if it exists in the database
 my $maggie = $users_rs->find({ username => "maggie" });
 $maggie->delete if defined($maggie);
 
-## get a list of users from the CSV file
+# Get a list of users from the CSV file
 my @students = loadCSV("$main::ww3_dir/t/db/sample_data/students.csv");
 
-# remove duplicates
+# Remove duplicates
 my %seen = ();
 @students = grep { !$seen{ $_->{username} }++ } @students;
-
-# dd \@unique;
-
 for my $student (@students) {
 	for my $key (qw/course_name recitation section params role/) {
 		delete $student->{$key};
@@ -61,7 +45,7 @@ for my $student (@students) {
 	$student->{is_admin} = 0;
 }
 
-# add the admin user
+# Add the admin user
 push(
 	@students,
 	{
@@ -75,21 +59,15 @@ push(
 );
 my @all_students = sort { $a->{username} cmp $b->{username} } @students;
 
-## get a list of all users
-
+# Get a list of all users
 my @users_from_db = $users_rs->getAllGlobalUsers;
 for my $user (@users_from_db) {
 	removeIDs($user);
 }
 @users_from_db = sort { $a->{username} cmp $b->{username} } @users_from_db;
-
 is_deeply(\@all_students, \@users_from_db, "getUsers: all users");
 
-# dd \@all_students;
-# dd \@users_from_db;
-
-## get one user that exists
-
+# Get one user that exists
 my $user = $users_rs->getGlobalUser({ username => $all_students[0]->{username} });
 removeIDs($user);
 delete $user->{role};
@@ -100,8 +78,7 @@ removeIDs($user);
 my @stud2 = grep { $_->{username} eq $user->{username} } @all_students;
 is_deeply($stud2[0], $user, "getUser: by user_id");
 
-## get one user that does not exist
-
+# Get one user that does not exist
 throws_ok {
 	$user = $users_rs->getGlobalUser({ user_id => -9 });
 }
@@ -112,8 +89,7 @@ throws_ok {
 }
 "DB::Exception::UserNotFound", "getUser: undefined username";
 
-## add one user
-
+# Add one user
 $user = {
 	username   => "wiggam",
 	last_name  => "Wiggam",
@@ -122,28 +98,24 @@ $user = {
 	student_id => '',
 	is_admin   => 0,
 };
-
 my $new_user = $users_rs->addGlobalUser($user);
 removeIDs($new_user);
 is_deeply($user, $new_user, "addUser: adding a user");
 
-## update a user
-
-my $updated_user = {%$user};    # make a copy of $user;
+# Update a user
+my $updated_user = {%$user};    # Make a copy of $user
 $updated_user->{email} = 'spring.cop@gmail.com';
 my $up_user_from_db = $users_rs->updateGlobalUser({ username => $updated_user->{username} }, $updated_user);
 removeIDs($up_user_from_db);
 is_deeply($updated_user, $up_user_from_db, "updateUser: updating a user");
 
-## try to update a user without passing username info:
-
+# Try to update a user without passing username info
 throws_ok {
 	$users_rs->updateGlobalUser({ username_name => "wiggam" }, $updated_user);
 }
 "DB::Exception::ParametersNeeded", "updateUser: wrong user_info sent";
 
-## try to update a user that doesn't exist:
-
+# Try to update a user that doesn't exist
 throws_ok {
 	$users_rs->updateGlobalUser({ username => "non_existent_user" }, $updated_user);
 }
@@ -154,15 +126,13 @@ throws_ok {
 }
 "DB::Exception::UserNotFound", "updateUser: update user for a non-existing user_id";
 
-## delete a user
-
+# Delete a user
 my $user_to_delete = $users_rs->deleteGlobalUser({ username => $user->{username} });
 
 delete $user_to_delete->{user_id};
 is_deeply($updated_user, $user_to_delete, "deleteUser: delete a user");
 
-## delete a user that doesn't exist.
-
+# Delete a user that doesn't exist.
 throws_ok {
 	$user = $users_rs->deleteGlobalUser({ username => "undefined_username" });
 }

--- a/t/db/006_quizzes.t
+++ b/t/db/006_quizzes.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
-#
+
 # This tests the basic database CRUD functions of problem sets of type quiz.
-#
+
 use warnings;
 use strict;
 
@@ -13,33 +13,22 @@ BEGIN {
 
 use lib "$main::ww3_dir/lib";
 
-use Text::CSV qw/csv/;
 use Test::More;
 use Test::Exception;
 use YAML::XS qw/LoadFile/;
 use Clone qw/clone/;
-
-use Array::Utils qw/array_minus intersect/;
 use DateTime::Format::Strptime;
 
-use DB::WithParams;
-use DB::WithDates;
 use DB::Schema;
-use DB::TestUtils qw/loadCSV removeIDs filterBySetType loadSchema/;
+use DB::TestUtils qw/loadCSV removeIDs filterBySetType/;
 
-# load the database
+# Load the database
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
-
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = LoadFile($config_file);
-
-my $schema =
-	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croak');
-
-# $schema->storage->debug(1);  # print out the SQL commands.
 
 my @hw_dates  = @DB::Schema::Result::ProblemSet::HWSet::VALID_DATES;
 my @hw_params = @DB::Schema::Result::ProblemSet::HWSet::VALID_PARAMS;
@@ -48,7 +37,7 @@ my $problem_set_rs = $schema->resultset("ProblemSet");
 my $course_rs      = $schema->resultset("Course");
 my $user_rs        = $schema->resultset("User");
 
-my @all_problem_sets;    # stores all problem_sets
+my @all_problem_sets;
 
 my @quizzes = loadCSV("$main::ww3_dir/t/db/sample_data/quizzes.csv");
 for my $quiz (@quizzes) {
@@ -59,79 +48,60 @@ for my $quiz (@quizzes) {
 	}
 }
 
-## remove the quiz: Quiz #9 if it exists:
-
+# Remove "Quiz #9" if it exists
 my $quiz_to_delete = $problem_set_rs->find({ set_name => "Quiz #9" });
 $quiz_to_delete->delete if defined($quiz_to_delete);
 
-## test: get all quizzes from one course
+# Test: Get all quizzes from one course
 my @precalc_quizzes = filterBySetType(\@quizzes, "QUIZ", "Precalculus");
-@precalc_quizzes = map {
-	{%$_};
-} @precalc_quizzes;    # clone all quizzes
-
 for my $quiz (@precalc_quizzes) {
 	delete $quiz->{course_name};
-	# delete $quiz->{type};
 }
 @precalc_quizzes = sort { $a->{set_name} cmp $b->{set_name} } @precalc_quizzes;
 my @precalc_quizzes_from_db = $problem_set_rs->getQuizzes({ course_name => "Precalculus" });
 
-# remove id tags:
+# Remove id tags
 for my $quiz (@precalc_quizzes_from_db) {
 	removeIDs($quiz);
 }
-
 is_deeply(\@precalc_quizzes, \@precalc_quizzes_from_db, "getQuizzes: get all quizzes for one course");
 
-# get a single quiz
-
+# Get a single quiz
 my $quiz_from_db = $problem_set_rs->getProblemSet({ course_name => "Precalculus", set_name => "Quiz #1" });
 removeIDs($quiz_from_db);
-
 my @quiz_from_csv = grep { $_->{set_name} eq "Quiz #1" } @precalc_quizzes;
-
 delete $quiz_from_csv[0]->{type};
-
 is_deeply($quiz_from_csv[0], $quiz_from_db, "getQuiz: get one quiz from a single course");
 
-# try to get a quiz that doesn't exist in a course that does:
-
+# Try to get a quiz that doesn't exist in a course that does.
 throws_ok {
 	$problem_set_rs->getProblemSet({ course_name => "Precalculus", set_name => "nonexisent quiz" });
 }
 "DB::Exception::SetNotInCourse", "getQuiz: non-existent set name";
 
-# try to get a quiz from a course that doesn't exist
-
+# Try to get a quiz from a course that doesn't exist.
 throws_ok {
 	$problem_set_rs->getProblemSet({ course_name => "nonexistent course", set_name => "Quiz #1" });
 }
 "DB::Exception::CourseNotFound", "getQuiz: try to get a quiz from a non-existent course";
 
-## add a new quiz
-
+# Add a new quiz
 my $new_quiz_params = {
 	set_name  => "Quiz #9",
 	set_dates => { open => 100, due => 140, answer => 200 },
 	set_type  => "QUIZ"
 };
-
 my $new_quiz = $problem_set_rs->addProblemSet({ course_name => "Precalculus" }, $new_quiz_params);
-
 removeIDs($new_quiz);
-
 is_deeply($new_quiz, $new_quiz_params, "addQuiz: add a new quiz");
 
-## try to add a quiz to a non existent course
-
+# Try to add a quiz to a non existent course.
 throws_ok {
 	$problem_set_rs->addProblemSet({ course_name => "nonexistent course", set_name => "Quiz #1" });
 }
 "DB::Exception::CourseNotFound", "addQuiz: try to add a quiz from a non-existent course";
 
-## try to add a quiz with non-valid parameters:
-
+# Try to add a quiz with non-valid parameters.
 throws_ok {
 	$problem_set_rs->addProblemSet(
 		{
@@ -146,8 +116,7 @@ throws_ok {
 }
 "DBIx::Class::Exception", "addQuiz: try to add a quiz with a bad parameter";
 
-## try to add a quiz without specifying the name:
-
+# Try to add a quiz without specifying the name.
 throws_ok {
 	$problem_set_rs->addProblemSet(
 		{
@@ -161,8 +130,7 @@ throws_ok {
 }
 "DB::Exception::ParametersNeeded", "addQuiz: try to add a quiz with a bad field";
 
-## try to add a quiz with an undefined parameter:
-
+# Try to add a quiz with an undefined parameter.
 throws_ok {
 	$problem_set_rs->addProblemSet(
 		{
@@ -185,8 +153,7 @@ throws_ok {
 }
 "DB::Exception::UndefinedParameter", "addQuiz: try to add a quiz with a undefined parameter";
 
-## try to add a quiz with a non-valid parameter:
-
+# Try to add a quiz with a non-valid parameter.
 throws_ok {
 	$problem_set_rs->addProblemSet(
 		{
@@ -209,8 +176,7 @@ throws_ok {
 }
 "DB::Exception::InvalidParameter", "addQuiz: try to add a quiz with a non-valid parameter";
 
-## try to add a quiz with a missing required date fields
-
+# Try to add a quiz with a missing required date fields.
 throws_ok {
 	$problem_set_rs->addProblemSet(
 		{
@@ -228,8 +194,7 @@ throws_ok {
 }
 "DB::Exception::RequiredDateFields", "addQuiz: try to add a quiz with a missing required date fields";
 
-## try to add a quiz with an undefined date field
-
+# Try to add a quiz with an undefined date field.
 throws_ok {
 	$problem_set_rs->addProblemSet(
 		{
@@ -250,8 +215,7 @@ throws_ok {
 }
 "DB::Exception::InvalidDateField", "addQuiz: try to add a quiz with an undefined date field";
 
-## try to add a quiz with dates that are out of order
-
+# Try to add a quiz with dates that are out of order.
 throws_ok {
 	$problem_set_rs->addProblemSet(
 		{
@@ -271,33 +235,26 @@ throws_ok {
 }
 "DB::Exception::ImproperDateOrder", "addQuiz: try to add a quiz with dates that are out of order";
 
-# update the visibility of the quiz
-
+# Update the visibility of the quiz
 my $updated_params = { set_visible => 0 };
-
-my $updated_quiz = $problem_set_rs->updateProblemSet(
+my $updated_quiz   = $problem_set_rs->updateProblemSet(
 	{
 		course_name => "Precalculus",
 		set_name    => "Quiz #9"
 	},
 	$updated_params
 );
-
 $new_quiz->{set_visible} = 0;
 $new_quiz->{set_params}  = {};
-
 removeIDs($updated_quiz);
-
 is_deeply($new_quiz, $updated_quiz, "updateQuiz: successfully update the quiz");
 
-# update the params of the quiz
-
+# Update the params of the quiz
 $updated_params = {
 	set_params => {
 		timed => 1
 	}
 };
-
 $updated_quiz = $problem_set_rs->updateProblemSet(
 	{
 		course_name => "Precalculus",
@@ -306,13 +263,10 @@ $updated_quiz = $problem_set_rs->updateProblemSet(
 	$updated_params
 );
 removeIDs($updated_quiz);
-
 $new_quiz->{set_params} = { timed => 1 };
-
 is_deeply($new_quiz, $updated_quiz, "updateQuiz: successfully update the params of the quiz");
 
-# update the dates of the quiz
-
+# Update the dates of the quiz
 $updated_params = {
 	set_dates => {
 		open   => 400,
@@ -320,7 +274,6 @@ $updated_params = {
 		answer => 600
 	}
 };
-
 $updated_quiz = $problem_set_rs->updateProblemSet(
 	{
 		course_name => "Precalculus",
@@ -329,13 +282,10 @@ $updated_quiz = $problem_set_rs->updateProblemSet(
 	$updated_params
 );
 removeIDs($updated_quiz);
-
 $new_quiz->{set_dates} = clone($updated_params->{set_dates});
-
 is_deeply($new_quiz, $updated_quiz, "updateQuiz: successfully update the dates of the quiz");
 
-# try to update a non-existent field of the quiz
-
+# Try to update a non-existent field of the quiz.
 throws_ok {
 	$problem_set_rs->updateProblemSet(
 		{
@@ -349,8 +299,7 @@ throws_ok {
 }
 "DBIx::Class::Exception", "updateQuiz: try to update a quiz with a non-valid field";
 
-# try to update a non-existent param of the quiz
-
+# Try to update a non-existent param of the quiz.
 throws_ok {
 	$problem_set_rs->updateProblemSet(
 		{
@@ -366,8 +315,7 @@ throws_ok {
 }
 "DB::Exception::UndefinedParameter", "updateQuiz: try to update a quiz with an undefined parameter";
 
-# try to update a parameter with a bad value
-
+# Try to update a parameter with a bad value
 throws_ok {
 	$problem_set_rs->updateProblemSet(
 		{
@@ -383,8 +331,7 @@ throws_ok {
 }
 "DB::Exception::InvalidParameter", "updateQuiz: try to update a quiz with a non-valid field";
 
-# try to update a quiz with an invalid  date
-
+# Try to update a quiz with an invalid  date
 throws_ok {
 	$problem_set_rs->updateProblemSet(
 		{
@@ -400,8 +347,7 @@ throws_ok {
 }
 "DB::Exception::InvalidDateField", "updateQuiz: try to update a quiz with a non-valid date";
 
-# try to update a quiz with a date out of order
-
+# Try to update a quiz with a date out of order.
 throws_ok {
 	$problem_set_rs->updateProblemSet(
 		{
@@ -418,8 +364,7 @@ throws_ok {
 }
 "DB::Exception::ImproperDateOrder", "updateQuiz: try to update a quiz with out of order dates";
 
-# try to delete from a non-existent course:
-
+# Try to delete from a non-existent course.
 throws_ok {
 	$problem_set_rs->deleteProblemSet({
 		course_name => "Course does not exist",
@@ -428,8 +373,7 @@ throws_ok {
 }
 "DB::Exception::CourseNotFound", 'deleteQuiz: try to delete a quiz from a non-existent course';
 
-# try to delete from a non-existent course:
-
+# Try to delete from a non-existent course.
 throws_ok {
 	$problem_set_rs->deleteProblemSet({
 		course_id => 9999,
@@ -438,8 +382,7 @@ throws_ok {
 }
 "DB::Exception::CourseNotFound", 'deleteQuiz: try to delete a quiz from a non-existent course_id';
 
-# try to delete from a non-existent set in a  course:
-
+# Try to delete from a non-existent set in a course.
 throws_ok {
 	$problem_set_rs->deleteProblemSet({
 		course_name => "Precalculus",
@@ -448,8 +391,7 @@ throws_ok {
 }
 "DB::Exception::SetNotInCourse", 'deleteQuiz: try to delete a non-existent quiz';
 
-# try to delete from a non-existent set in a  course:
-
+# Try to delete from a non-existent set in a course.
 throws_ok {
 	$problem_set_rs->deleteProblemSet({
 		course_name => "Precalculus",
@@ -458,18 +400,14 @@ throws_ok {
 }
 "DB::Exception::SetNotInCourse", 'deleteQuiz: try to delete a non-existent quiz as set_id';
 
-# try to delete from a non-existent set in a  course:
-
+# Try to delete from a non-existent set in a  course:
 my $deleted_quiz = $problem_set_rs->deleteProblemSet({
 	course_name => "Precalculus",
 	set_name    => "Quiz #9"
 });
-
 removeIDs($deleted_quiz);
 is_deeply($deleted_quiz, $new_quiz, "delete Quiz: successfully delete a quiz");
 
 done_testing;
-
-## helpful subroutines
 
 1;

--- a/t/db/007_user_set.t
+++ b/t/db/007_user_set.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
-#
+
 # This tests the basic database CRUD functions of problem sets of type quiz.
-#
+
 use warnings;
 use strict;
 
@@ -13,48 +13,36 @@ BEGIN {
 
 use lib "$main::ww3_dir/lib";
 
-use Text::CSV qw/csv/;
 use DateTime::Format::Strptime;
 
 use Test::More;
 use Clone qw/clone/;
 use Test::Exception;
 use List::MoreUtils qw/firstval/;
-use Try::Tiny;
 use YAML::XS qw/LoadFile/;
 
 use DB::Schema;
-use DB::TestUtils qw/loadCSV removeIDs loadSchema/;
+use DB::TestUtils qw/loadCSV removeIDs/;
 
-## get user set info from csv files
-
-## get the database
-
+# Load the database
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
-
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = LoadFile($config_file);
-
-my $schema =
-	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croak');
-
-# $schema->storage->debug(1);  # print out the SQL commands.
 
 my $user_set_rs    = $schema->resultset("UserSet");
 my $course_rs      = $schema->resultset("Course");
 my $course_user_rs = $schema->resultset("CourseUser");
 my $course         = $course_rs->find({ course_id => 1 });
 
-# temporarily delete the added set
+# Temporarily delete the added set
 my $u                   = $course_user_rs->find({ user_id => 12 });
 my $user_sets_to_delete = $user_set_rs->search({ course_user_id => $u->course_user_id });
 $user_sets_to_delete->delete_all if $user_sets_to_delete;
 
-# load info from CSV files
-
+# Load info from CSV files
 my @hw_sets = loadCSV("$main::ww3_dir/t/db/sample_data/hw_sets.csv");
 for my $hw_set (@hw_sets) {
 	$hw_set->{set_type}    = "HW";
@@ -66,8 +54,7 @@ for my $hw_set (@hw_sets) {
 }
 my @all_user_sets = loadCSV("$main::ww3_dir/t/db/sample_data/user_sets.csv");
 
-# merge the sets
-
+# Merge the sets
 for my $user_set (@all_user_sets) {
 	my $hw_set = firstval {
 		$_->{course_name} eq $user_set->{course_name}
@@ -75,8 +62,8 @@ for my $user_set (@all_user_sets) {
 	}
 	@hw_sets;
 
-	# determine params and dates overrides
-	my $params = clone($hw_set->{set_params});    # copy the params from the hw_set
+	# Determine params and dates overrides
+	my $params = clone($hw_set->{set_params});
 	for my $key (keys %{ $user_set->{set_params} }) {
 		$params->{$key} = $user_set->{set_params}->{$key};
 	}
@@ -91,18 +78,15 @@ for my $user_set (@all_user_sets) {
 	$user_set->{set_visible} = $hw_set->{set_visible};
 }
 
-## get all user set for a given user in a course
-
+# Get all user set for a given user in a course.
 my @user_sets_from_db = $user_set_rs->getUserSetsForUser({
 	course_name => $course->course_name,
 	username    => "homer"
 });
-
-my @user_sets = map {
-	{ %{$_} };
-} @all_user_sets;    # make a copy of the sets
-
-@user_sets = grep { $_->{course_name} eq $course->course_name && $_->{username} eq "homer" } @user_sets;
+my @user_sets = grep { $_->{course_name} eq $course->course_name && $_->{username} eq "homer" }
+	map {
+	{%$_}
+	} @all_user_sets;
 
 for my $user_set (@user_sets) {
 	delete $user_set->{course_name};
@@ -115,14 +99,12 @@ for my $user_set (@user_sets_from_db) {
 
 is_deeply(\@user_sets_from_db, \@user_sets, "getUserSets: get all user sets for a user in a course");
 
-## get all user sets for a given set in a course
-
+# Get all user sets for a given set in a course.
 @user_sets_from_db = $user_set_rs->getUserSetsForSet({ course_name => "Precalculus", set_name => "HW #1" });
-
-@user_sets = map {
-	{ %{$_} };
-} @all_user_sets;    # make a copy of the sets
-@user_sets = grep { $_->{course_name} eq "Precalculus" && $_->{set_name} eq "HW #1" } @user_sets;
+@user_sets         = grep { $_->{course_name} eq "Precalculus" && $_->{set_name} eq "HW #1" }
+	map {
+	{%$_}
+	} @all_user_sets;
 
 for my $user_set (@user_sets) {
 	delete $user_set->{course_name};
@@ -135,29 +117,25 @@ for my $user_set (@user_sets_from_db) {
 
 is_deeply(\@user_sets_from_db, \@user_sets, "getUserSets: get all user sets for a set in a course");
 
-## try to get a user set from a non-existing course
-
+# Try to get a user set from a non-existing course.
 throws_ok {
 	$user_set_rs->getUserSetsForUser({ course_name => "non_existent_course", username => "homer" });
 }
 "DB::Exception::CourseNotFound", "getUserSets: attempt to get user sets from a nonexistent course";
 
-## try to get a user set from a non-existing course
-
+# Try to get a user set from a non-existing course.
 throws_ok {
 	$user_set_rs->getUserSetsForUser({ course_name => "Precalculus", username => "non_existent_user" });
 }
 "DB::Exception::UserNotInCourse", "getUserSets: attempt to get user sets from a nonexistent user";
 
-## try to get a user set from a user not in the course
-
+# Try to get a user set from a user not in the course.
 throws_ok {
 	$user_set_rs->getUserSetsForUser({ course_name => "non_existent_course", username => "bart" });
 }
 "DB::Exception::CourseNotFound", "getUserSets: attempt to get user sets from user not in the course";
 
-## get a single UserSet
-
+# Get a single UserSet
 my $info = {
 	username    => "homer",
 	course_name => "Precalculus",
@@ -165,24 +143,21 @@ my $info = {
 };
 my $user_set = $user_set_rs->getUserSet($info);
 
-my @sets = map {
-	{ %{$_} };
-} @all_user_sets;    # make a copy
 my $user_set_from_csv = firstval {
 	$_->{course_name} eq "Precalculus"
 		&& $_->{username} eq $info->{username}
 		&& $_->{set_name} eq $info->{set_name}
 }
-@sets;
+map {
+	{%$_}
+} @all_user_sets;
 
 removeIDs($user_set);
 delete $user_set->{type};
 delete $user_set_from_csv->{course_name};
-
 is_deeply($user_set_from_csv, $user_set, "getUserSet: get a user set from a course");
 
-## try to get a user set from a non-existent course
-
+# Try to get a user set from a non-existent course.
 throws_ok {
 	$user_set_rs->getUserSet({
 		course_name => "non_existent_course",
@@ -192,8 +167,7 @@ throws_ok {
 }
 "DB::Exception::CourseNotFound", "getUserSet: try to get a user set from a non-existent course";
 
-## try to get a user set from a non-existent user
-
+# Try to get a user set from a non-existent user.
 throws_ok {
 	$user_set_rs->getUserSet({
 		course_name => "Precalculus",
@@ -203,8 +177,7 @@ throws_ok {
 }
 "DB::Exception::UserNotInCourse", "getUserSet: try to get a user set from a non-existent user";
 
-## try to get a user set from a user not in the course
-
+# Try to get a user set from a user not in the course.
 throws_ok {
 	$user_set_rs->getUserSet({
 		course_name => "Precalculus",
@@ -214,8 +187,7 @@ throws_ok {
 }
 "DB::Exception::UserNotInCourse", "getUserSet: try to get a user set not in the course";
 
-## try to get a user set from a non-existent set
-
+# Try to get a user set from a non-existent set.
 throws_ok {
 	$user_set_rs->getUserSet({
 		course_name => "Precalculus",
@@ -225,8 +197,7 @@ throws_ok {
 }
 "DB::Exception::SetNotInCourse", "getUserSet: try to get a user set from a non-existent set";
 
-# add a user set
-
+# Add a user set
 my $new_user_set_info = {
 	username    => "otto",
 	course_name => "Precalculus",
@@ -235,12 +206,11 @@ my $new_user_set_info = {
 
 my $new_user_set = $user_set_rs->addUserSet($new_user_set_info);
 
-my $hw_sets = clone(\@hw_sets);
-my $set     = firstval {
+my $set = firstval {
 	$_->{course_name} eq $new_user_set_info->{course_name}
 		&& $_->{set_name} eq $new_user_set_info->{set_name}
 }
-@$hw_sets;
+@{ clone(\@hw_sets) };
 
 $set->{username} = $new_user_set_info->{username};
 removeIDs($new_user_set);
@@ -249,8 +219,7 @@ delete $new_user_set->{type};
 
 is_deeply($new_user_set, $set, "addUserSet: add a new user set");
 
-# try to add a user set to a course that doesn't exist
-
+# Try to add a user set to a course that doesn't exist.
 throws_ok {
 	$user_set_rs->addUserSet({
 		username    => "otto",
@@ -260,8 +229,7 @@ throws_ok {
 }
 "DB::Exception::CourseNotFound", "addUserSet: add a user set to a non-existent course";
 
-# try to add a user set for a set that does not exist in a course
-
+# Try to add a user set for a set that does not exist in a course.
 throws_ok {
 	$user_set_rs->addUserSet({
 		username    => "otto",
@@ -271,8 +239,7 @@ throws_ok {
 }
 "DB::Exception::SetNotInCourse", "addUserSet: try to add a user set to a non-existent set";
 
-# try to add a user set for a user that is not in a course
-
+# Try to add a user set for a user that is not in a course.
 throws_ok {
 	$user_set_rs->addUserSet({
 		username    => "ralph",
@@ -282,8 +249,7 @@ throws_ok {
 }
 "DB::Exception::UserNotInCourse", "addUserSet: try to add a user set for a user who is not in the course";
 
-# try to add a user set with bad fields
-
+# Try to add a user set with bad fields.
 throws_ok {
 	$user_set_rs->addUserSet(
 		{
@@ -298,8 +264,7 @@ throws_ok {
 }
 "DBIx::Class::Exception", "addUserSet: try to add a user set with a bad field";
 
-# try to add a user_set that already exists
-
+# Try to add a user_set that already exists.
 throws_ok {
 	$user_set_rs->addUserSet({
 		username    => "otto",
@@ -309,12 +274,7 @@ throws_ok {
 }
 "DB::Exception::UserSetExists", "addUserSet: try to add a user set that already exists";
 
-## add a user set with valid params
-
-# first delete if it exists.
-# my $set2 = $user_set_rs->find({user_id=>12, set_id=>2});
-# $set2->delete if defined($set2);
-
+# Add a user set with valid params.
 my $user_set2 = $user_set_rs->addUserSet(
 	{
 		username    => "otto",
@@ -328,12 +288,11 @@ my $user_set2 = $user_set_rs->addUserSet(
 	}
 );
 
-$hw_sets = clone(\@hw_sets);
 my $set2_from_csv = firstval {
 	$_->{course_name} eq "Precalculus"
 		&& $_->{set_name} eq $user_set2->{set_name}
 }
-@$hw_sets;
+@{ clone(\@hw_sets) };
 
 removeIDs($user_set2);
 delete $set2_from_csv->{course_name};
@@ -343,8 +302,7 @@ $set2_from_csv->{username}   = $user_set2->{username};
 
 is_deeply($user_set2, $set2_from_csv, "addUserSet: add a new user set with params");
 
-## try to add a user set with a bad field
-
+# Try to add a user set with a bad field.
 throws_ok {
 	$user_set_rs->addUserSet(
 		{
@@ -361,13 +319,12 @@ throws_ok {
 }
 "DB::Exception::UndefinedParameter", "addUserSet: try to add a new user set with an undefined parameter";
 
-# delete the user set from from above
+# Delete the user set from from above.
 my $cu            = $course_user_rs->find({ user_id => 12 }, 1);
 my $set_to_delete = $user_set_rs->find({ course_user_id => $cu->course_user_id, set_id => 2 });
 $set_to_delete->delete if defined($set_to_delete);
 
-## add a user set with a new date
-
+# Add a user set with a new date.
 my $user_set3 = $user_set_rs->addUserSet(
 	{
 		username    => "otto",
@@ -383,13 +340,11 @@ my $user_set3 = $user_set_rs->addUserSet(
 	}
 );
 
-$hw_sets = clone(\@hw_sets);    # make a copy
-
 my $set3_from_csv = firstval {
 	$_->{course_name} eq "Precalculus"
 		&& $_->{set_name} eq $user_set3->{set_name}
 }
-@$hw_sets;
+@{ clone(\@hw_sets) };
 
 removeIDs($user_set3);
 delete $set3_from_csv->{course_name};
@@ -398,8 +353,7 @@ $set3_from_csv->{username}  = $user_set3->{username};
 
 is_deeply($user_set3, $set3_from_csv, "addUserSet: add a new user set with dates");
 
-## try to add a bad date
-
+# Try to add a bad date.
 throws_ok {
 	$user_set_rs->addUserSet(
 		{
@@ -436,18 +390,15 @@ throws_ok {
 }
 "DB::Exception::ImproperDateOrder", "addUserSet: dates are out of order";
 
-## Update User Set
+# Update User Set
 
-# update the dates
-
+# Update the dates
 my $updated_dates = {
 	open   => 1,
 	due    => 10,
 	answer => 20
 };
-
 $set3_from_csv->{set_dates} = $updated_dates;
-
 my $updated_user_set = $user_set_rs->updateUserSet(
 	{
 		username    => "otto",
@@ -458,13 +409,10 @@ my $updated_user_set = $user_set_rs->updateUserSet(
 		set_dates => $updated_dates
 	}
 );
-
 removeIDs($updated_user_set);
-
 is_deeply($updated_user_set, $set3_from_csv, "updateUserSet: update the dates");
 
-# update the params
-
+# Update the params
 my $updated_user_set2 = $user_set_rs->updateUserSet(
 	{
 		username    => "otto",
@@ -477,14 +425,11 @@ my $updated_user_set2 = $user_set_rs->updateUserSet(
 		}
 	}
 );
-
 removeIDs($updated_user_set2);
 $set3_from_csv->{set_params}->{hide_hint} = 1;
-
 is_deeply($updated_user_set2, $set3_from_csv, "updateUserSet: update the params");
 
-# try updating an invalid field
-
+# Try updating an invalid field.
 my $updated_user_set3 = $user_set_rs->updateUserSet(
 	{
 		username    => "otto",
@@ -499,8 +444,7 @@ $set3_from_csv->{set_version} = 2;
 removeIDs($updated_user_set3);
 is_deeply($set3_from_csv, $updated_user_set3, "updateUserSet: update the set version");
 
-# try updating an invalid field
-
+# Try updating an invalid field.
 throws_ok {
 	$user_set_rs->updateUserSet(
 		{
@@ -517,8 +461,7 @@ throws_ok {
 }
 "DB::Exception::UndefinedParameter", "updateUserSet: try setting a parameter that is not allowed to be updated";
 
-# try updating an invalid date
-
+# Try updating an invalid date.
 throws_ok {
 	$user_set_rs->updateUserSet(
 		{
@@ -533,8 +476,7 @@ throws_ok {
 }
 "DB::Exception::InvalidDateField", "updateUserSet: try to update an invalid date field";
 
-# missing required dates
-
+# Try to update a set with missing required dates
 throws_ok {
 	$user_set_rs->updateUserSet(
 		{
@@ -549,8 +491,7 @@ throws_ok {
 }
 "DB::Exception::RequiredDateFields", "updateUserSet: try to update with missing required dates";
 
-# out of order dates
-
+# Try to update a set with out of order dates.
 throws_ok {
 	$user_set_rs->updateUserSet(
 		{
@@ -565,8 +506,7 @@ throws_ok {
 }
 "DB::Exception::ImproperDateOrder", "updateUserSet: try to update with out of order dates";
 
-# update a user_set that doesn't exist;
-
+# Try to update a user_set that doesn't exist.
 throws_ok {
 	$user_set_rs->updateUserSet(
 		{
@@ -583,20 +523,16 @@ throws_ok {
 }
 "DB::Exception::UserSetNotInCourse", "updateUserSet: try to update a user set not the in the course";
 
-# delete a user set
-
+# Delete a user set.
 my $deleted_user_set = $user_set_rs->deleteUserSet({
 	username    => "otto",
 	course_name => "Precalculus",
 	set_name    => "HW #2"
 });
-
 removeIDs($deleted_user_set);
-
 is_deeply($deleted_user_set, $set3_from_csv, "deleteUserSet: successfully delete a user set");
 
-# delete a user_set that doesn't exist;
-
+# Delete a user_set that doesn't exist.
 throws_ok {
 	$user_set_rs->deleteUserSet({
 		username    => "otto",

--- a/t/db/008_problem_pools.t
+++ b/t/db/008_problem_pools.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
-#
+
 # This tests the basic database CRUD functions of Pool Problems.
-#
+
 use warnings;
 use strict;
 
@@ -15,42 +15,29 @@ use lib "$main::ww3_dir/lib";
 
 use Test::More;
 use Test::Exception;
-use Try::Tiny;
-use Carp;
 use YAML::XS qw/LoadFile/;
 
-use List::MoreUtils qw/uniq/;
-
-use DB::WithParams;
-use DB::WithDates;
 use DB::Schema;
-use DB::TestUtils qw/loadCSV removeIDs loadSchema/;
+use DB::TestUtils qw/loadCSV removeIDs/;
 
-# Set up the database
+# Load the database
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
-
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = LoadFile($config_file);
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
-my $schema =
-	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
-
-# $schema->storage->debug(1);  # print out the SQL commands.
-
-## load problem pools from the csv files:
-
+# Load problem pools from the csv files.
 my @pool_problems_from_file = loadCSV("$main::ww3_dir/t/db/sample_data/pool_problems.csv");
 
 my @problem_pools_from_file = map {
-	{%$_};
-} @pool_problems_from_file;    # copy the array
+	{%$_}
+} @pool_problems_from_file;
 for my $pool (@problem_pools_from_file) {
 	delete $pool->{library_id};
 	delete $pool->{params};
 }
 
-## get an array of unique problem pools by pool_name
+# Get an array of unique problem pools by pool_name.
 my %seen;
 @problem_pools_from_file = grep { !$seen{ $_->{pool_name} }++ } @problem_pools_from_file;
 
@@ -73,8 +60,7 @@ for my $pool (@precalc_pools) {
 
 is_deeply(\@precalc_pools_from_file, \@precalc_pools, "getProblemPools: get all problem pools from a single course");
 
-## get a problem pool
-
+# Get a problem pool
 my $pool_to_fetch = $problem_pools_from_file[0];
 
 my $fetched_pool = $problem_pool_rs->getProblemPool($pool_to_fetch);
@@ -83,22 +69,19 @@ $fetched_pool->{course_name} = $problem_pools_from_file[0]->{course_name};
 
 is_deeply($pool_to_fetch, $fetched_pool, "getProblemPool: get a single pool from a course");
 
-## throws_ok to get a problem pool from a course that doesn't exist.
-
+# Try to get a problem pool from a course that doesn't exist.
 throws_ok {
 	$problem_pool_rs->getProblemPool({ course_name => "not existent course", pool_name => "adding fractions" });
 }
 "DB::Exception::CourseNotFound", "getProblemPool: get a problem pool from a non-existent course";
 
-## throws_ok to get a problem pool from a course, but the pool doesn't exist.
-
+# Try to get a problem pool from a course, but the pool doesn't exist.
 throws_ok {
 	$problem_pool_rs->getProblemPool({ course_name => "Arithmetic", pool_name => "non_existent_pool" });
 }
 "DB::Exception::PoolNotInCourse", "getProblemPool: get a problem pool from a non-existent course";
 
-## add a problem pool
-
+# Add a problem pool
 my $course_name = 'Arithmetic';
 my $pool_name   = 'subtracting fractions';
 
@@ -107,30 +90,26 @@ removeIDs($pool2);
 
 is_deeply(
 	{
-		# course_name => $course_name,
 		pool_name => $pool_name
 	},
 	$pool2,
 	"addProblemPool: add a new problem pool to a course"
 );
 
-## addProblemPool to a pool that already exists
-
+# Try to add a pool that already exists.
 throws_ok {
 	$problem_pool_rs->addProblemPool({ course_name => 'Arithmetic' }, { pool_name => "adding fractions" });
 }
 "DB::Exception::PoolAlreadyInCourse", "addProblemPool: pool already exists";
 
-## addProblemPool with a pool with non-valid field
-
+# Try to add a pool with an invalid field.
 throws_ok {
 	$problem_pool_rs->addProblemPool({ course_name => 'Arithmetic' },
 		{ pool_name => "multiplying fractions", other_field => "XXX" });
 }
 "DBIx::Class::Exception", "addProblemPool: add a pool with non-valid field";
 
-## update an existing problem pool
-
+# Update an existing problem pool.
 my $updated_pool = { pool_name => "subtracting fractions with like denominators", };
 
 my $updated_pool_from_db =
@@ -143,33 +122,27 @@ $updated_pool->{course_name} = 'Arithmetic';
 
 is_deeply($updated_pool, $updated_pool_from_db, "updateProblemPool: update the name of a problem pool");
 
-## throws_ok to update a pool that doesn't exist
+# TODO: Try to update a pool that doesn't exist.
 
-## throws_ok to get a problem pool from a course that doesn't exist.
-
+# Try to get a problem pool from a course that doesn't exist.
 throws_ok {
 	$problem_pool_rs->updateProblemPool({ course_name => 'non_existent_course', pool_name => 'XXXX' }, $updated_pool);
 }
 "DB::Exception::CourseNotFound", "udpateProblemPool: update a problem pool from a non-existent course";
 
-## throws_ok to get a problem pool from a course, but the pool doesn't exist.
-
+# Try to get a non-existent problem pool from a course.
 throws_ok {
 	$problem_pool_rs->updateProblemPool({ course_name => "Arithmetic", pool_name => "non_existent_pool" },
 		$updated_pool);
 }
 "DB::Exception::PoolNotInCourse", "updateProblemPool: update a problem pool from a non-existent course";
 
-## get a PoolProblem (a problem within a ProblemPool)
-
-my $prob2 = $pool_problems_from_file[0];
-
+# Get a PoolProblem (a problem within a ProblemPool).
+my $prob2         = $pool_problems_from_file[0];
 my $pool_problem2 = $problem_pool_rs->getPoolProblem($prob2);
-
 is($prob2->{library_id}, $pool_problem2->{library_id}, "getPoolProblem: get a single problem from a problem pool");
 
-## get a random PoolProblem
-
+# Get a random PoolProblem
 my $random_prob = $problem_pool_rs->getPoolProblem({
 	course_name => $prob2->{course_name},
 	pool_name   => $prob2->{pool_name}
@@ -182,10 +155,8 @@ my @arr     = grep { $_ == $random_prob->{params}->{library_id} } @lib_ids;
 
 ok(scalar(@arr) == 1, "getPoolProblem: get a random problem from a problem pool");
 
-## add a Problem to a pool
-
+# Add a Problem to a pool
 my $prob_to_add->{params} = { library_id => 8332 };
-
 my $added_problem = $problem_pool_rs->addProblemToPool($updated_pool, $prob_to_add);
 
 is(
@@ -194,8 +165,7 @@ is(
 	"addProblemToPool: adding a problem to an existing pool."
 );
 
-### check that adding a problem to a non-existence course fails
-
+# Check that adding a problem to a non-existence course fails.
 throws_ok {
 	$problem_pool_rs->addProblemToPool(
 		{
@@ -207,8 +177,7 @@ throws_ok {
 }
 "DB::Exception::CourseNotFound", "addProblemToPool: try to add to a nonexisting course";
 
-### check that adding a problem to a non-existence pool fails
-
+# Check that adding a problem to a non-existence pool fails.
 throws_ok {
 	$problem_pool_rs->addProblemToPool(
 		{
@@ -220,8 +189,7 @@ throws_ok {
 }
 "DB::Exception::PoolNotInCourse", "addProblemToPool: try to add to a nonexisting pool";
 
-## update a pool problem
-
+# Update a pool problem
 my $course_pool_problem_info = {%$updated_pool_from_db};
 $course_pool_problem_info->{pool_problem_id} = $added_problem->{pool_problem_id};
 
@@ -236,8 +204,7 @@ is(
 	"updatePoolProblem: update an existing problem in an existing pool."
 );
 
-### check that updating a problem to a non-existence course fails
-
+# Check that updating a problem to a non-existence course fails.
 throws_ok {
 	$problem_pool_rs->updatePoolProblem(
 		{
@@ -254,8 +221,7 @@ throws_ok {
 }
 "DB::Exception::CourseNotFound", "updatePoolProblem: try to update a nonexisting course";
 
-### check that updating a problem to a non-existence course fails
-
+# Check that updating a problem to a non-existence course fails.
 throws_ok {
 	$problem_pool_rs->updatePoolProblem(
 		{
@@ -268,8 +234,7 @@ throws_ok {
 }
 "DB::Exception::PoolNotInCourse", "updatePoolProblem: try to update  a nonexisting pool";
 
-### check that updating a problem to a non-existing problem fails.
-
+# Check that updating a problem to a non-existing problem fails.
 throws_ok {
 	$problem_pool_rs->updatePoolProblem(
 		{
@@ -282,11 +247,10 @@ throws_ok {
 }
 "DB::Exception::PoolProblemNotInPool", "updatePoolProblem: try to update a nonexisting problem";
 
-## delete a problem pool
+# Delete a problem pool
 my $pool_to_delete = $problem_pool_rs->deleteProblemPool($updated_pool);
 removeIDs($pool_to_delete);
 $pool_to_delete->{course_name} = 'Arithmetic';
-
 is_deeply($updated_pool, $pool_to_delete, "deleteProblemPool: delete an existing problem pool");
 
 done_testing;

--- a/t/db/009_problems.t
+++ b/t/db/009_problems.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
-#
+
 # This tests the basic database CRUD functions of problems.
-#
+
 use warnings;
 use strict;
 
@@ -13,47 +13,34 @@ BEGIN {
 
 use lib "$main::ww3_dir/lib";
 
-use Data::Dumper;
 use Test::More;
 use Test::Exception;
-use Try::Tiny;
-use Carp;
 use Clone qw/clone/;
 use YAML::XS qw/LoadFile/;
 
-use Array::Utils qw/array_minus intersect/;
-
-use DB::WithParams;
-use DB::WithDates;
 use DB::Schema;
-use DB::TestUtils qw/loadCSV removeIDs loadSchema/;
+use DB::TestUtils qw/loadCSV removeIDs/;
 use DB::Utils qw/updateAllFields/;
 
-# set up the database
+# Load the database
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
-
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = LoadFile($config_file);
-
-my $schema =
-	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
-
-# $schema->storage->debug(1);  # print out the SQL commands.
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $problem_rs     = $schema->resultset("Problem");
 my $problem_set_rs = $schema->resultset("ProblemSet");
 
-# load all problems from the CVS files
+# Load all problems from the CVS files.
 my @problems_from_csv = loadCSV("$main::ww3_dir/t/db/sample_data/problems.csv");
 for my $problem (@problems_from_csv) {
 	$problem->{problem_version} = 1 unless defined($problem->{problem_version});
 }
 
-# filter out precalc problems
+# Filter out precalc problems
 my @precalc_problems = grep { $_->{course_name} eq "Precalculus" } @problems_from_csv;
 
-# filter out "HW #1"
+# Filter out "HW #1"
 my @precalc_problems1 = grep { $_->{set_name} eq "HW #1" } @precalc_problems;
 
 for my $problem (@problems_from_csv) {
@@ -73,8 +60,7 @@ for my $problem (@problems_from_db) {
 
 is_deeply(\@all_problems, \@problems_from_db, "getGlobalProblems: get all problems");
 
-## get all problems from one course
-
+# Get all problems from one course.
 my @precalc_problems_from_db = $problem_rs->getProblems({ course_name => "Precalculus" });
 for my $problem (@precalc_problems_from_db) {
 	removeIDs($problem);
@@ -86,8 +72,7 @@ for my $problem (@precalc_problems) {
 
 is_deeply(\@precalc_problems, \@precalc_problems_from_db, "getProblems: get all problems from one course");
 
-## get all problems in one course from one set.
-
+# Get all problems in one course from one set.
 my @set_problems1 = $problem_rs->getSetProblems({ course_name => "Precalculus", set_name => "HW #1" });
 
 for my $problem (@set_problems1) {
@@ -96,22 +81,19 @@ for my $problem (@set_problems1) {
 
 is_deeply(\@precalc_problems1, \@set_problems1, "getSetProblems: get all problems from one set");
 
-## try to get problems from a non-existing course
-
+# Try to get problems from a non-existing course.
 throws_ok {
 	$problem_rs->getSetProblems({ course_name => "non_existing_course", set_name => "HW #1" });
 }
 "DB::Exception::CourseNotFound", "getSetProblem: get problems from non-existing course";
 
-## try to get problems from a non-existing set
-
+# Try to get problems from a non-existing set.
 throws_ok {
 	$problem_rs->getSetProblems({ course_name => "Precalculus", set_name => "HW #999" });
 }
 "DB::Exception::SetNotInCourse", "getSetProblems: get problems from non-existing set";
 
-## get a single problem from a course:
-
+# Get a single problem from a course.
 my $set_problem = $problem_rs->getSetProblem({
 	course_name    => "Precalculus",
 	set_name       => "HW #1",
@@ -119,14 +101,13 @@ my $set_problem = $problem_rs->getSetProblem({
 });
 removeIDs($set_problem);
 
-my $expected_problem = { %{ $problems_from_csv[0] } };    # copy the first problem
+my $expected_problem = { %{ $problems_from_csv[0] } };    # Copy the first problem
 delete $expected_problem->{set_name};
 delete $expected_problem->{course_name};
 
 is_deeply($expected_problem, $set_problem, "getSetProblem: get a single problem from a set in a given course");
 
-## add a problem to an existing set
-
+# Add a problem to an existing set.
 my $new_problem = {
 	problem_number => 4,
 	problem_params => {
@@ -147,8 +128,7 @@ removeIDs($prob1);
 
 is_deeply($new_problem, $prob1, "addProblem: add a valid problem to a set");
 
-## update a problem
-
+# Update a problem
 my $updated_params = {
 	problem_number => 99,
 	problem_params => {
@@ -171,8 +151,7 @@ $all_params->{problem_version} = 1 unless defined $all_params->{problem_version}
 
 is_deeply($all_params, $updated_problem, "updateProblem: update a problem");
 
-## delete a problem from a set
-
+# Delete a problem from a set
 my $deleted_problem = $problem_rs->deleteSetProblem({
 	course_name    => "Precalculus",
 	set_name       => "HW #1",

--- a/t/db/010_set_versions.t
+++ b/t/db/010_set_versions.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
-#
+
 # This tests the basic database CRUD functions of problem sets.
-#
+
 use warnings;
 use strict;
 
@@ -13,31 +13,18 @@ BEGIN {
 
 use lib "$main::ww3_dir/lib";
 
-use Data::Dumper;
-use List::MoreUtils qw(uniq);
 use Test::More;
 use Test::Exception;
-use Try::Tiny;
 use YAML::XS qw/LoadFile/;
 
-use Array::Utils qw/array_minus intersect/;
-
-use DB::WithParams;
-use DB::WithDates;
 use DB::Schema;
-use DB::TestUtils qw/loadCSV removeIDs filterBySetType loadSchema/;
+use DB::TestUtils qw/loadCSV/;
 
-# setup the database
+# Load the database
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
-
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = LoadFile($config_file);
-
-my $schema =
-	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
-
-# $schema->storage->debug(1);  # print out the SQL commands.
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my @hw_dates  = @DB::Schema::Result::ProblemSet::HWSet::VALID_DATES;
 my @hw_params = @DB::Schema::Result::ProblemSet::HWSet::VALID_PARAMS;
@@ -46,7 +33,7 @@ my $problem_set_rs = $schema->resultset("ProblemSet");
 my $course_rs      = $schema->resultset("Course");
 my $user_rs        = $schema->resultset("User");
 
-# load HW sets from CSV file
+# Load HW sets from CSV file.
 my @hw_sets = loadCSV("$main::ww3_dir/t/db/sample_data/hw_sets.csv");
 for my $set (@hw_sets) {
 	$set->{type}        = 1;
@@ -56,6 +43,7 @@ for my $set (@hw_sets) {
 
 $problem_set_rs->newSetVersion({ course_id => 1, set_id => 1 });
 
+# TODO: Write actual tests for this.
 is_deeply({ test => 1 }, { test => 1 }, 'fake test');
 
 done_testing;

--- a/t/db/run_all_tests.pl
+++ b/t/db/run_all_tests.pl
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-# run all tests in this directory
+# Run all tests in this directory.
 
 use TAP::Harness;
 use Data::Dump qw/dd/;

--- a/t/mojolicious/001_login.t
+++ b/t/mojolicious/001_login.t
@@ -4,17 +4,21 @@ use Mojo::Base -strict;
 
 use Test::More;
 use Test::Mojo;
+use YAML::XS qw/LoadFile/;
 
 BEGIN {
 	use File::Basename qw/dirname/;
 	use Cwd qw/abs_path/;
-	$main::test_dir = abs_path(dirname(__FILE__));
-	$main::lib_dir  = dirname(dirname($main::test_dir)) . '/lib';
+	$main::ww3_dir = abs_path(dirname(__FILE__)) . '/../..';
 }
 
-use lib "$main::lib_dir";
+use lib "$main::ww3_dir/lib";
 
-my $t = Test::Mojo->new('WeBWorK3');
+# Load the config file.
+my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
+
+my $t = Test::Mojo->new('WeBWorK3' => LoadFile($config_file));
 
 # Test missing credentials
 $t->post_ok('/webwork3/api/login')->status_is(250, 'error status')->content_type_is('application/json;charset=UTF-8')

--- a/t/mojolicious/002_courses.t
+++ b/t/mojolicious/002_courses.t
@@ -15,19 +15,16 @@ use lib "$main::ww3_dir/lib";
 
 use Getopt::Long;
 my $TEST_PERMISSIONS;
-GetOptions("perm" => \$TEST_PERMISSIONS);    # check for the flag --perm when running this.
+GetOptions("perm" => \$TEST_PERMISSIONS);
 
-use DB::Schema;
 use Clone qw/clone/;
-
-# this tests the api with common courses routes
-
 use YAML::XS qw/LoadFile/;
 
-my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
+# Test the api with common "courses" routes.
 
+# Load the config file.
+my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = clone(LoadFile($config_file));
 
 my $t;
@@ -36,7 +33,6 @@ if ($TEST_PERMISSIONS) {
 	$config->{ignore_permissions} = 0;
 	$t = Test::Mojo->new(WeBWorK3 => $config);
 
-	# and login
 	$t->post_ok('/api/login' => json => { email => 'admin@google.com', password => 'admin' })
 		->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)->json_is('/user/user_id' => 1)
 		->json_is('/user/is_admin' => 1);
@@ -52,8 +48,7 @@ $t->get_ok('/webwork3/api/courses')->content_type_is('application/json;charset=U
 $t->get_ok('/webwork3/api/courses/1')->content_type_is('application/json;charset=UTF-8')
 	->json_is('/course_name' => "Precalculus")->json_is('/visible' => 1);
 
-## add a new course
-
+# Add a new course
 my $new_course = {
 	course_name  => "Linear Algebra",
 	course_dates => { start => "2021-05-31", end => "2021-07-01" }
@@ -62,51 +57,45 @@ my $new_course = {
 $t->post_ok('/webwork3/api/courses' => json => $new_course)->status_is(200)
 	->json_is('/course_name' => $new_course->{course_name});
 
-# Pull out the id from the response
+# Extract the id from the response.
 my $new_course_id = $t->tx->res->json('/course_id');
 $new_course->{course_id} = $new_course_id;
 is_deeply($new_course, $t->tx->res->json, "addCourse: courses match");
 
-## update the course
-
+# Update the course
 $new_course->{visible} = 0;
 $t->put_ok("/webwork3/api/courses/$new_course_id" => json => $new_course)->status_is(200)
 	->json_is('/course_name' => $new_course->{course_name});
 
 is_deeply($new_course, $t->tx->res->json, "updateCourse: courses match");
 
-## test for exceptions
+# Test for exceptions
 
-# a set that is not in a course
+# A set that is not in a course.
 $t->get_ok("/webwork3/api/courses/99999")->status_is(250, 'error status')
 	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::CourseNotFound');
 
-# try to update a non-existant course
-
+# Try to update a non-existent course
 $t->put_ok("/webwork3/api/courses/999999" => json => { course_name => 'new course name' })
 	->status_is(250, 'error status')->content_type_is('application/json;charset=UTF-8')
 	->json_is('/exception' => 'DB::Exception::CourseNotFound');
 
-# try to add a course without a course_name
-
+# Try to add a course without a course_name.
 my $another_new_course = { name => "this is the wrong field" };
 
 $t->post_ok("/webwork3/api/courses/" => json => $another_new_course)->status_is(250, 'error status')
 	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::ParametersNeeded');
 
-# try to delete a non-existent course.
+# Try to delete a non-existent course.
 $t->delete_ok("/webwork3/api/courses/9999999")->status_is(250, 'error status')
 	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::CourseNotFound');
 
-# delete the added course
-
+# Delete the added course.
 $t->delete_ok("/webwork3/api/courses/$new_course_id")->status_is(200)
 	->json_is('/course_name' => $new_course->{course_name});
 
-## login a non admin user
-
 if ($TEST_PERMISSIONS) {
-
+	# Login a non admin user
 	$t->post_ok('/webwork3/api/login' => json => { email => 'lisa@google.com', password => 'lisa' })
 		->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
 		->json_is('/user/login' => "lisa")->json_is('/user/is_admin' => 0);
@@ -117,7 +106,7 @@ if ($TEST_PERMISSIONS) {
 	$t->get_ok('/webwork3/api/courses/1')->content_type_is('application/json;charset=UTF-8')
 		->json_is('/course_name' => "Precalculus")->json_is('/course_params/institution' => "Springfield CC");
 
-	# the following shouldn't have permissions for these routes.
+	# The following shouldn't have permissions for these routes.
 
 	$t->post_ok('/webwork3/api/courses' => json => $new_course)->status_is(200)->json_is('/has_permission' => 0);
 

--- a/t/mojolicious/004_course_users.t
+++ b/t/mojolicious/004_course_users.t
@@ -15,24 +15,21 @@ use lib "$main::ww3_dir/lib";
 
 use Getopt::Long;
 my $TEST_PERMISSIONS;
-GetOptions("perm" => \$TEST_PERMISSIONS);    # check for the flag --perm when running this.
+GetOptions("perm" => \$TEST_PERMISSIONS);
 
-use Data::Dumper;
 use DB::Schema;
 use Clone qw/clone/;
 use YAML::XS qw/LoadFile/;
 
-my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
+# Test the api with common "courses/users" routes.
 
+# Load the config file.
+my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = clone(LoadFile($config_file));
 
-# Test the api with common "courses" routes
-
-# set up the database:
-my $schema =
-	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
+# Connect to the database.
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $t;
 
@@ -40,7 +37,6 @@ if ($TEST_PERMISSIONS) {
 	$config->{ignore_permissions} = 0;
 	$t = Test::Mojo->new(WeBWorK3 => $config);
 
-	# username an admin
 	$t->post_ok('/webwork3/api/username' => json => { email => 'admin@google.com', password => 'admin' })
 		->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
 		->json_is('/user/user_id' => 1)->json_is('/user/is_admin' => 1);
@@ -50,7 +46,7 @@ if ($TEST_PERMISSIONS) {
 	$t = Test::Mojo->new(WeBWorK3 => $config);
 }
 
-# remove the maggie user if exists in the database
+# Remove the user "maggie" if it exists in the database.
 my $maggie = $schema->resultset("User")->find({ username => "maggie" });
 if (defined($maggie)) {
 	my $maggie_cu = $schema->resultset("CourseUser")->search({ user_id => $maggie->user_id });
@@ -61,14 +57,13 @@ if (defined($maggie)) {
 $t->get_ok('/webwork3/api/courses/4/users')->status_is(200)->content_type_is('application/json;charset=UTF-8')
 	->json_is('/0/role' => "instructor")->json_is('/1/role' => 'student');
 
-# Pull out the id from the response
+# Extract id from the response.
 my $user_id = $t->tx->res->json('/0/user_id');
 
 $t->get_ok("/webwork3/api/courses/2/users/$user_id")->status_is(200)->content_type_is('application/json;charset=UTF-8')
 	->json_is('/user_id' => $user_id)->json_is('/role' => "student");
 
-## add a new global user
-
+# Add a new global user.
 my $new_user = {
 	email      => 'maggie@abc.com',
 	first_name => "Maggie",
@@ -76,15 +71,12 @@ my $new_user = {
 	username   => "maggie",
 	student_id => "1234123423"
 };
-
 $t->post_ok("/webwork3/api/users" => json => $new_user)->status_is(200)
 	->content_type_is('application/json;charset=UTF-8')->json_is('/first_name' => $new_user->{first_name})
 	->json_is('/email' => $new_user->{email});
 
-# then add the user to a course
-
-my $new_user_id = $t->tx->res->json('/user_id');
-
+# Add the user to a course.
+my $new_user_id        = $t->tx->res->json('/user_id');
 my $course_user_params = {
 	user_id => $new_user_id,
 	role    => "student",
@@ -97,40 +89,37 @@ $t->post_ok("/webwork3/api/courses/2/users" => json => $course_user_params)->sta
 	->content_type_is('application/json;charset=UTF-8')->json_is('/role' => $course_user_params->{role})
 	->json_is('/params/comment' => $course_user_params->{params}->{comment});
 
-# update the new user
-
+# Update the new user.
 $new_user->{recitation} = 2;
 $t->put_ok("/webwork3/api/courses/2/users/$new_user_id" => json => { recitation => 2 })->status_is(200)
 	->content_type_is('application/json;charset=UTF-8')->json_is('/recitation' => 2);
 
-## test for exceptions
+# Test for exceptions
 
-# a non-existent user
+# A non-existent user
 $t->get_ok("/webwork3/api/courses/1/users/99999")->status_is(250, "status for exception")
 	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::UserNotFound');
 
-# check that a new is not in a course
+# Check that a new user is not in a course.
 $t->get_ok("/webwork3/api/courses/1/users/$new_user_id")->status_is(250, "status for exception")
 	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::UserNotInCourse');
 
-# try to update a user not in a course
-
+# Try to update a user that is not in a course.
 $t->put_ok("/webwork3/api/courses/1/users/$new_user_id" => json => { recitation => '2' })
 	->status_is(250, "status for exception")->content_type_is('application/json;charset=UTF-8')
 	->json_is('/exception' => 'DB::Exception::UserNotInCourse');
 
-# try to add a user without a username
-
+# Try to add a user without a username.
 my $another_new_user = { username_name => "this is the wrong field" };
 
 $t->post_ok("/webwork3/api/courses/1/users" => json => $another_new_user)->status_is(250, "status for exception")
 	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::ParametersNeeded');
 
-# try to delete a user not found
+# Try to delete a user that is not found.
 $t->delete_ok("/webwork3/api/courses/1/users/99")->status_is(250, "status for exception")
 	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::UserNotFound');
 
-# try to delete a user not in a course
+# Try to delete a user that is not in a course.
 $t->delete_ok("/webwork3/api/courses/1/users/$new_user_id")->status_is(250, "status for exception")
 	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::UserNotInCourse');
 
@@ -141,8 +130,7 @@ if ($TEST_PERMISSIONS) {
 	$t->post_ok("/webwork3/api/logout")->status_is(200)->json_is('/logged_in' => 0);
 }
 
-## check that a non_admin user has proper access.
-
+# Check that a non_admin user has proper access.
 my @all_users   = $schema->resultset("User")->getCourseUsers({ course_id => 1 });
 my @instructors = grep { $_->{role} eq 'instructor' } @all_users;
 
@@ -155,7 +143,6 @@ if ($TEST_PERMISSIONS) {
 	)->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1);
 
 	$t->get_ok('/webwork3/api/courses/1/users')->status_is(200)->content_type_is('application/json;charset=UTF-8');
-
 }
 
 done_testing;

--- a/t/mojolicious/005_problem_sets.t
+++ b/t/mojolicious/005_problem_sets.t
@@ -4,6 +4,7 @@ use Mojo::Base -strict;
 
 use Test::More;
 use Test::Mojo;
+
 use DateTime::Format::Strptime;
 
 BEGIN {
@@ -16,24 +17,23 @@ use lib "$main::ww3_dir/lib";
 
 use Getopt::Long;
 my $TEST_PERMISSIONS;
-GetOptions("perm" => \$TEST_PERMISSIONS);    # check for the flag --perm when running this.
+GetOptions("perm" => \$TEST_PERMISSIONS);
 
 use DB::Schema;
 use Clone qw/clone/;
 use YAML::XS qw/LoadFile/;
 use DB::TestUtils qw/loadCSV/;
 
-my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
+# Test the api with common "courses/sets" routes.
 
+# Load the config file.
+my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = clone(LoadFile($config_file));
 
 my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croak');
 
-# Test the api with common "sets" routes
-
-# set up the database:
+# Connect to the database.
 my $schema =
 	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
@@ -43,7 +43,6 @@ if ($TEST_PERMISSIONS) {
 	$config->{ignore_permissions} = 1;
 	$t = Test::Mojo->new(WeBWorK3 => $config);
 
-	# username an admin
 	$t->post_ok('/webwork3/api/username' => json => { email => 'admin@google.com', password => 'admin' })
 		->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
 		->json_is('/user/user_id' => 1)->json_is('/user/is_admin' => 1);
@@ -52,8 +51,7 @@ if ($TEST_PERMISSIONS) {
 	$t = Test::Mojo->new(WeBWorK3 => $config);
 }
 
-# load the homework sets
-
+# Load the homework sets.
 my @hw_sets = loadCSV("$main::ww3_dir/t/db/sample_data/hw_sets.csv");
 for my $set (@hw_sets) {
 	$set->{set_type} = "HW";
@@ -67,7 +65,7 @@ $t->get_ok('/webwork3/api/courses/2/sets')->status_is(200)->content_type_is('app
 	->json_is('/1/set_name'       => $hw_sets[1]->{set_name})
 	->json_is('/1/set_dates/open' => $hw_sets[1]->{set_dates}->{open});
 
-# Pull out the id from the response
+# Extract the id from the response.
 my $set_id = $t->tx->res->json('/2/set_id');
 
 # Disabled for now until this is fixed.
@@ -75,8 +73,7 @@ $t->get_ok("/webwork3/api/courses/2/sets/$set_id")->status_is(200)->content_type
 	->json_is('/set_name'       => $hw_sets[2]->{set_name})->json_is('/set_type' => $hw_sets[2]->{set_type})
 	->json_is('/set_dates/open' => $hw_sets[2]->{set_dates}->{open});
 
-# new problem set
-
+# Create a new problem set
 my $new_set = {
 	set_name  => 'HW #9',
 	set_dates => {
@@ -94,30 +91,27 @@ my $new_set_id = $t->tx->res->json('/set_id');
 $t->put_ok("/webwork3/api/courses/2/sets/$new_set_id" => json => { set_name => 'HW #11' })
 	->content_type_is('application/json;charset=UTF-8')->json_is('/set_name' => 'HW #11');
 
-## test for exceptions
+# Test for exceptions
 
-# a set that is not in a course
+# A set that is not in a course
 $t->get_ok("/webwork3/api/courses/1/sets/6")->content_type_is('application/json;charset=UTF-8')
 	->json_is('/exception' => 'DB::Exception::SetNotInCourse');
 
-# try to update a set not in a course
-
+# Try to update a set not in a course
 $t->put_ok("/webwork3/api/courses/1/sets/6" => json => { set_name => 'HW #99' })
 	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::SetNotInCourse');
 
-# try to add a set without a setname
-
+# Try to add a set without a setname.
 my $another_new_set = { name => "this is the wrong field" };
 
 $t->post_ok("/webwork3/api/courses/2/sets" => json => $another_new_set)
 	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::ParametersNeeded');
 
-# delete an existing set
-
+# Delete an existing set.
 $t->delete_ok("/webwork3/api/courses/2/sets/$new_set_id")->content_type_is('application/json;charset=UTF-8')
 	->json_is('/set_name' => 'HW #11');
 
-# try to delete a set not in a course
+# Try to delete a set not in a course.
 $t->delete_ok("/webwork3/api/courses/1/sets/6")->content_type_is('application/json;charset=UTF-8')
 	->json_is('/exception' => 'DB::Exception::SetNotInCourse');
 
@@ -125,8 +119,7 @@ if ($TEST_PERMISSIONS) {
 	$t->post_ok("/webwork3/api/logout")->status_is(200)->json_is('/logged_in' => 0);
 }
 
-## check that a non_admin user has proper access.
-
+# Check that a non-admin user has proper access.
 my @all_users   = $schema->resultset("User")->getCourseUsers({ course_id => 1 });
 my @instructors = grep { $_->{role} eq 'instructor' } @all_users;
 
@@ -136,10 +129,6 @@ if ($TEST_PERMISSIONS) {
 		->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1);
 
 	$t->get_ok('/webwork3/api/courses/1/sets')->status_is(200)->content_type_is('application/json;charset=UTF-8');
-
-	# ->json_is('/0' => $all_users[0]->{first_name});
-
-	# dd $t->tx->res->json;
 }
 
 done_testing;

--- a/t/mojolicious/006_quizzes.t
+++ b/t/mojolicious/006_quizzes.t
@@ -17,26 +17,24 @@ use lib "$main::ww3_dir/lib";
 
 use Getopt::Long;
 my $TEST_PERMISSIONS;
-GetOptions("perm" => \$TEST_PERMISSIONS);    # check for the flag --perm when running this.
+GetOptions("perm" => \$TEST_PERMISSIONS);
 
 use DB::Schema;
-use DB::TestUtils qw/loadSchema loadCSV/;
 use Clone qw/clone/;
 use YAML::XS qw/LoadFile/;
+use DB::TestUtils qw/loadCSV/;
 
+# Test the api with common "courses/sets" routes for quizzes.
+
+# Load the config file.
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
-	unless (-e $config_file);
-
+$config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = clone(LoadFile($config_file));
 
 my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croak');
 
-# this tests the api with common courses routes
-
-# set up the database:
-my $schema =
-	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
+# Connect to the database.
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $t;
 
@@ -44,7 +42,6 @@ if ($TEST_PERMISSIONS) {
 	$config->{ignore_permissions} = 1;
 	$t = Test::Mojo->new(WeBWorK3 => $config);
 
-	# username an admin
 	$t->post_ok('/webwork3/api/username' => json => { email => 'admin@google.com', password => 'admin' })
 		->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
 		->json_is('/user/user_id' => 1)->json_is('/user/is_admin' => 1);
@@ -54,8 +51,7 @@ if ($TEST_PERMISSIONS) {
 	$t = Test::Mojo->new(WeBWorK3 => $config);
 }
 
-# load the quizzes
-
+# Load the quizzes.
 my @quizzes = loadCSV("$main::ww3_dir/t/db/sample_data/quizzes.csv");
 for my $quiz (@quizzes) {
 	$quiz->{set_type} = "QUIZ";

--- a/tests/unit-tests/quizzes.spec.ts
+++ b/tests/unit-tests/quizzes.spec.ts
@@ -2,7 +2,7 @@
 /// <reference types="jest" />
 
 import { Quiz, ProblemSet } from 'src/store/models/problem_sets';
-import { BooleanParseException, InvalidFieldsException, NonNegIntException } from 'src/store/models';
+import { BooleanParseException, NonNegIntException } from 'src/store/models';
 
 test('Build a Quiz', () => {
 	const quiz = new Quiz();


### PR DESCRIPTION
Instead of complaining about the *.yml configuration files not existing, just use the *.dist.yml files in that case.  This way the workflow doesn't need to copy the .dist files, it just uses them.

There is some other clean up of comments included as well.