### PR TITLE
Update the internationalization setup.

### DIFF
--- a/conf/course_defaults.yml
+++ b/conf/course_defaults.yml
@@ -29,28 +29,32 @@
   category: general
   doc: Default language for the course
   doc2: >
-    WeBWorK currently has translations for four languages: "English en", "Turkish tr", "Spanish es", and "French fr"
+    WeBWorK currently has translations for the following languages:
+      "English en", "French fr", and "German de"
   type: list
   options:
     -
-      label: English
-      value: en-us
+      label: English (US)
+      value: en-US
     -
-      label: Turkish
-      value: tr
+      label: Deutsch
+      value: de
     -
-      label: Spanish
-      value: es
-    -
-      label: French
+      label: français
       value: fr
-    -
-      label: Chinese (Hong Kong)
-      value: zh_hk
-    -
-      label: Hebrew
-      value: he
-  default: en-us  # select default value here
+    #-
+    #  label: Chinese (Hong Kong)
+    #  value: zh_hk
+    #-
+    #  label: Hebrew
+    #  value: he
+    #-
+    #  label: Spanish
+    #  value: es
+    #-
+    #  label: Turkish
+    #  value: tr
+  default: en-US  # select default value here
 -
   var: per_problem_lang_and_dir_setting_mode
   category: general

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 			},
 			"devDependencies": {
 				"@babel/eslint-parser": "^7.13.14",
+				"@intlify/vue-i18n-loader": "^3.2.0",
 				"@quasar/app": "^3.2.1",
 				"@types/bootstrap": "^5.1.6",
 				"@types/jest": "^27.0.2",
@@ -1857,6 +1858,44 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"node_modules/@intlify/bundle-utils": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@intlify/bundle-utils/-/bundle-utils-1.0.0.tgz",
+			"integrity": "sha512-/lV9CZpQVOBhXgsfHsPEQP3VvdQGsgx8INQIVUsNOgdw0Ddy884h1OJlRBMInyOIxDgjFa7/Wpqe2Zxt7ueuEg==",
+			"dev": true,
+			"dependencies": {
+				"@intlify/core": "^9.1.9",
+				"@intlify/message-compiler": "^9.1.9",
+				"@intlify/shared": "^9.1.9",
+				"jsonc-eslint-parser": "^1.0.1",
+				"source-map": "^0.6.1",
+				"yaml-eslint-parser": "^0.3.2"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/@intlify/bundle-utils/node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@intlify/core": {
+			"version": "9.1.9",
+			"resolved": "https://registry.npmjs.org/@intlify/core/-/core-9.1.9.tgz",
+			"integrity": "sha512-y+B2KaLGYYrbcq4kXhTn9JBphlAyC351l47TMfK9xBEXTXRzgEpXTzTJ23Y85GBwOCembRehQ82sjjtGmJuRjA==",
+			"dev": true,
+			"dependencies": {
+				"@intlify/core-base": "9.1.9"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/@intlify/core-base": {
 			"version": "9.1.9",
 			"resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.1.9.tgz",
@@ -1945,6 +1984,57 @@
 			},
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/@intlify/vue-i18n-loader": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@intlify/vue-i18n-loader/-/vue-i18n-loader-3.3.0.tgz",
+			"integrity": "sha512-c+UpjGUAkZV9XJzrJouDAxuEG2co9+ywbEzdyAPL/EPcEf6+q25979QYX0WOHBsU2FG55xTSfy/9Kn71X2LvgA==",
+			"dev": true,
+			"dependencies": {
+				"@intlify/bundle-utils": "^1.0.0",
+				"@intlify/shared": "^9.1.9",
+				"js-yaml": "^4.1.0",
+				"json5": "^2.2.0",
+				"loader-utils": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 12"
+			},
+			"peerDependencies": {
+				"vue": "^3.0.0 || ^2.6.0"
+			}
+		},
+		"node_modules/@intlify/vue-i18n-loader/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/@intlify/vue-i18n-loader/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@intlify/vue-i18n-loader/node_modules/loader-utils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+			"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+			"dev": true,
+			"dependencies": {
+				"big.js": "^5.2.2",
+				"emojis-list": "^3.0.0",
+				"json5": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=8.9.0"
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -8051,20 +8141,6 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
-		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -11420,6 +11496,45 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/jsonc-eslint-parser": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-1.4.1.tgz",
+			"integrity": "sha512-hXBrvsR1rdjmB2kQmUjf1rEIa+TqHBGMge8pwi++C+Si1ad7EjZrJcpgwym+QGK/pqTx+K7keFAtLlVNdLRJOg==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^7.4.1",
+				"eslint-utils": "^2.1.0",
+				"eslint-visitor-keys": "^1.3.0",
+				"espree": "^6.0.0",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/jsonc-eslint-parser/node_modules/eslint-visitor-keys": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/jsonc-eslint-parser/node_modules/espree": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^7.1.1",
+				"acorn-jsx": "^5.2.0",
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/jsonfile": {
@@ -18275,6 +18390,26 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/yaml-eslint-parser": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-0.3.2.tgz",
+			"integrity": "sha512-32kYO6kJUuZzqte82t4M/gB6/+11WAuHiEnK7FreMo20xsCKPeFH5tDBU7iWxR7zeJpNnMXfJyXwne48D0hGrg==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^1.3.0",
+				"lodash": "^4.17.20",
+				"yaml": "^1.10.0"
+			}
+		},
+		"node_modules/yaml-eslint-parser/node_modules/eslint-visitor-keys": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -19589,6 +19724,37 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"@intlify/bundle-utils": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@intlify/bundle-utils/-/bundle-utils-1.0.0.tgz",
+			"integrity": "sha512-/lV9CZpQVOBhXgsfHsPEQP3VvdQGsgx8INQIVUsNOgdw0Ddy884h1OJlRBMInyOIxDgjFa7/Wpqe2Zxt7ueuEg==",
+			"dev": true,
+			"requires": {
+				"@intlify/core": "^9.1.9",
+				"@intlify/message-compiler": "^9.1.9",
+				"@intlify/shared": "^9.1.9",
+				"jsonc-eslint-parser": "^1.0.1",
+				"source-map": "^0.6.1",
+				"yaml-eslint-parser": "^0.3.2"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"@intlify/core": {
+			"version": "9.1.9",
+			"resolved": "https://registry.npmjs.org/@intlify/core/-/core-9.1.9.tgz",
+			"integrity": "sha512-y+B2KaLGYYrbcq4kXhTn9JBphlAyC351l47TMfK9xBEXTXRzgEpXTzTJ23Y85GBwOCembRehQ82sjjtGmJuRjA==",
+			"dev": true,
+			"requires": {
+				"@intlify/core-base": "9.1.9"
+			}
+		},
 		"@intlify/core-base": {
 			"version": "9.1.9",
 			"resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.1.9.tgz",
@@ -19655,6 +19821,47 @@
 				"@intlify/message-resolver": "9.1.9",
 				"@intlify/runtime": "9.1.9",
 				"@intlify/shared": "9.1.9"
+			}
+		},
+		"@intlify/vue-i18n-loader": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@intlify/vue-i18n-loader/-/vue-i18n-loader-3.3.0.tgz",
+			"integrity": "sha512-c+UpjGUAkZV9XJzrJouDAxuEG2co9+ywbEzdyAPL/EPcEf6+q25979QYX0WOHBsU2FG55xTSfy/9Kn71X2LvgA==",
+			"dev": true,
+			"requires": {
+				"@intlify/bundle-utils": "^1.0.0",
+				"@intlify/shared": "^9.1.9",
+				"js-yaml": "^4.1.0",
+				"json5": "^2.2.0",
+				"loader-utils": "^2.0.0"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"dev": true,
+					"requires": {
+						"argparse": "^2.0.1"
+					}
+				},
+				"loader-utils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+					"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				}
 			}
 		},
 		"@istanbuljs/load-nyc-config": {
@@ -24438,13 +24645,6 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
-		"fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"optional": true
-		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -26890,6 +27090,38 @@
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
+			}
+		},
+		"jsonc-eslint-parser": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-1.4.1.tgz",
+			"integrity": "sha512-hXBrvsR1rdjmB2kQmUjf1rEIa+TqHBGMge8pwi++C+Si1ad7EjZrJcpgwym+QGK/pqTx+K7keFAtLlVNdLRJOg==",
+			"dev": true,
+			"requires": {
+				"acorn": "^7.4.1",
+				"eslint-utils": "^2.1.0",
+				"eslint-visitor-keys": "^1.3.0",
+				"espree": "^6.0.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				},
+				"espree": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+					"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+					"dev": true,
+					"requires": {
+						"acorn": "^7.1.1",
+						"acorn-jsx": "^5.2.0",
+						"eslint-visitor-keys": "^1.1.0"
+					}
+				}
 			}
 		},
 		"jsonfile": {
@@ -32051,6 +32283,25 @@
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
 			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
 			"dev": true
+		},
+		"yaml-eslint-parser": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-0.3.2.tgz",
+			"integrity": "sha512-32kYO6kJUuZzqte82t4M/gB6/+11WAuHiEnK7FreMo20xsCKPeFH5tDBU7iWxR7zeJpNnMXfJyXwne48D0hGrg==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^1.3.0",
+				"lodash": "^4.17.20",
+				"yaml": "^1.10.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				}
+			}
 		},
 		"yargs": {
 			"version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 	"devDependencies": {
 		"@babel/eslint-parser": "^7.13.14",
 		"@quasar/app": "^3.2.1",
+		"@intlify/vue-i18n-loader": "^3.2.0",
 		"@types/bootstrap": "^5.1.6",
 		"@types/jest": "^27.0.2",
 		"@types/jquery": "^3.5.8",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -85,6 +85,14 @@ module.exports = configure(function (ctx) {
 						}
 					}
 				});
+
+				// For i18n resources (json/json5/yaml)
+				cfg.module.rules.push({
+					test: /\.(json5?|ya?ml)$/,
+					type: 'javascript/auto',
+					include: [ path.resolve(__dirname, './src/locales') ],
+					loader: '@intlify/vue-i18n-loader'
+				});
 			}
 		},
 

--- a/src/boot/i18n.ts
+++ b/src/boot/i18n.ts
@@ -1,15 +1,24 @@
 import { boot } from 'quasar/wrappers';
+import type { LocaleMessageDictionary, VueMessageType } from 'vue-i18n';
 import { createI18n } from 'vue-i18n';
-import messages from 'src/i18n';
 
 const i18n = createI18n({
-	locale: 'en-US',
-	messages
+	legacy: false,
+	globalInjection: true,
+	fallbackLocale: 'en-US'
 });
 
-// "async" is optional;
-// more info on params: https://v2.quasar.dev/quasar-cli/boot-files
 export default boot(({ app }) => {
 	// Set i18n instance on app
 	app.use(i18n);
+
+	// Load the fallback locale
+	void setI18nLanguage('en-US');
 });
+
+export const setI18nLanguage = async (locale: string) => {
+	const messages: unknown = await import(/* webpackChunkName: "locale-[request]" */ `src/locales/${locale}.yml`);
+	i18n.global.setLocaleMessage(locale, (messages as { default: LocaleMessageDictionary<VueMessageType> }).default);
+	i18n.global.locale.value = locale;
+	document.querySelector('html')?.setAttribute('lang', locale);
+};

--- a/src/components/common/Login.vue
+++ b/src/components/common/Login.vue
@@ -23,6 +23,7 @@
 <script lang="ts">
 import { useRouter } from 'vue-router';
 import { defineComponent, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useStore } from 'src/store';
 import { checkPassword } from 'src/api-requests/session';
 
@@ -33,6 +34,7 @@ export default defineComponent({
 		const username = ref('');
 		const password = ref('');
 		const message = ref('');
+		const i18n = useI18n({ useScope: 'global' });
 
 		const store = useStore();
 		const login = async () => {
@@ -42,7 +44,7 @@ export default defineComponent({
 			};
 			const session = await checkPassword(username_info);
 			if (!session.logged_in) {
-				message.value = session.message;
+				message.value = i18n.t('authentication.failure');
 			} else {
 				// success
 				void store.dispatch('session/updateSessionInfo', session);

--- a/src/i18n/de/index.ts
+++ b/src/i18n/de/index.ts
@@ -1,7 +1,0 @@
-export default {
-	calendar: {
-		today: 'heute',
-		prev_week: 'letzte Woche',
-		next_week: 'nächste Woche'
-	}
-};

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1,8 +1,0 @@
-
-export default {
-	calendar: {
-		today: 'Today',
-		prev_week: 'Previous Week',
-		next_week: 'Next Week'
-	}
-};

--- a/src/i18n/fr/index.ts
+++ b/src/i18n/fr/index.ts
@@ -1,7 +1,0 @@
-export default {
-	calendar: {
-		today: 'aujourd\'hui',
-		prev_week: 'semaine précédente',
-		next_week: 'semaine prochaine'
-	}
-};

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,9 +1,0 @@
-import enUS from './en-US';
-import de from './de';
-import fr from './fr';
-
-export default {
-	'en-US': enUS,
-	'de': de,
-	'fr': fr
-};

--- a/src/layouts/MenuBar.vue
+++ b/src/layouts/MenuBar.vue
@@ -18,8 +18,10 @@
 					<q-space />
 					<q-btn-dropdown v-if="logged_in" color="secondary" icon="person" :label="full_name">
 						<q-list>
-							<q-item clickable @click="open_user_settings = true">User Settings</q-item>
-							<q-item clickable v-close-popup @click="logout">Logout</q-item>
+							<q-item clickable v-close-popup @click="open_user_settings = true">
+								{{ $t('menu_bar.user_settings') }}
+							</q-item>
+							<q-item clickable v-close-popup @click="logout">{{ $t('authentication.logout') }}</q-item>
 						</q-list>
 					</q-btn-dropdown>
 					<q-btn-dropdown color="secondary" :label="current_course_name" v-if="current_course_name"
@@ -35,7 +37,7 @@
 							</template>
 						</q-list>
 					</q-btn-dropdown>
-					<q-btn flat @click="$emit('toggle-sidebar')" round dense icon="vertical_split" />
+					<q-btn flat @click="$emit('toggle-sidebar')" round dense icon="vertical_split" class="q-ml-xs" />
 				</q-toolbar>
 			</div>
 		</div>
@@ -43,11 +45,12 @@
 	<q-dialog medium v-model="open_user_settings">
 		<q-card style="width: 300px">
 			<q-card-section>
-				<div class="text-h6">User Settings</div>
+				<div class="text-h6">{{ $t('menu_bar.user_settings') }}</div>
 			</q-card-section>
 
 			<q-card-section class="q-pt-none">
-				<q-select label="Language" v-model="$i18n.locale" :options="$i18n.availableLocales" />
+				<q-select label="Language" v-model="currentLocale" :options="availableLocales" emit-value map-options
+					@update:model-value="setI18nLanguage" />
 			</q-card-section>
 			<q-card-actions align="right" class="bg-white text-teal">
 				<q-btn flat label="OK" v-close-popup />
@@ -63,7 +66,10 @@ import { useStore } from 'src/store';
 import { useRouter } from 'vue-router';
 import { useRoute } from 'vue-router';
 import { UserCourse } from 'src/store/models/courses';
+import type { CourseSettingInfo } from 'src/store/models/settings';
 import { endSession } from 'src/api-requests/session';
+import { useI18n } from 'vue-i18n';
+import { setI18nLanguage } from 'boot/i18n';
 
 export default defineComponent({
 	name: 'MenuBar',
@@ -73,6 +79,7 @@ export default defineComponent({
 		const router = useRouter();
 		const route = useRoute();
 		const current_view = ref('');
+		const currentLocale = ref(useI18n({ useScope: 'global' }).locale.value);
 
 		const current_course_name = computed(() => store.state.session.course.course_name);
 
@@ -100,6 +107,14 @@ export default defineComponent({
 				}
 				void store.dispatch('session/setCourse', { course_name, course_id });
 			},
+			currentLocale,
+			availableLocales: computed(() => {
+				const language_setting = store.state.settings.default_settings.find(
+					(setting: CourseSettingInfo) => setting.var === 'language'
+				);
+				return language_setting?.options;
+			}),
+			setI18nLanguage,
 			open_user_settings: ref(false),
 			current_view,
 			logout: async () => {

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -1,0 +1,16 @@
+---
+  authentication:
+    # Your authentication failed.  Please try again.  Please speak with your instructor if you need help.
+    failure: null
+    # Logout
+    logout: null
+  menu_bar:
+    # User Settings
+    user_settings: Benutzereinstellungen
+  calendar:
+    # Today
+    today: heute
+    # Previous Week
+    prev_week: letzte Woche
+    # Next Week
+    next_week: nächste Woche

--- a/src/locales/en-US.yml
+++ b/src/locales/en-US.yml
@@ -1,0 +1,10 @@
+---
+  authentication:
+    failure: Your authentication failed.  Please try again.  Please speak with your instructor if you need help.
+    logout: Logout
+  menu_bar:
+    user_settings: User Settings
+  calendar:
+    today: Today
+    prev_week: Previous Week
+    next_week: Next Week

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -1,0 +1,16 @@
+---
+  authentication:
+    # Your authentication failed.  Please try again.  Please speak with your instructor if you need help.
+    failure: null
+    # Logout
+    logout: null
+  menu_bar:
+    # User Settings
+    user_settings: Paramètres utilisateur
+  calendar:
+    # Today
+    today: aujourd'hui
+    # Previous Week
+    prev_week: semaine précédente
+    # Next Week
+    next_week: semaine prochaine

--- a/src/pages/instructor/Instructor.vue
+++ b/src/pages/instructor/Instructor.vue
@@ -6,6 +6,7 @@
 import { defineComponent } from 'vue';
 import { useRoute } from 'vue-router';
 import { useStore } from 'src/store';
+import { setI18nLanguage } from 'boot/i18n';
 
 export default defineComponent({
 	name: 'Instructor',
@@ -33,6 +34,10 @@ export default defineComponent({
 		await store.dispatch('problem_sets/fetchSetProblems', route.params.course_id);
 		await store.dispatch('settings/fetchDefaultSettings');
 		await store.dispatch('settings/fetchCourseSettings', route.params.course_id);
+
+		// Set the language from the course settings.
+		await setI18nLanguage((store.getters as { [key: string]: (var_name: string) => string })
+			['settings/get_setting_value']('language'));
 	}
 });
 </script>

--- a/src/pages/instructor/Settings.vue
+++ b/src/pages/instructor/Settings.vue
@@ -33,7 +33,7 @@
 <script lang="ts">
 import { defineComponent, computed, ref } from 'vue';
 import { useStore } from 'src/store';
-import { CourseSettingInfo, CourseSetting } from 'src/store/models/settings';
+import type { CourseSettingInfo, CourseSetting } from 'src/store/models/settings';
 import SingleSetting from 'src/components/instructor/SingleSetting.vue';
 
 export default defineComponent({
@@ -52,12 +52,8 @@ export default defineComponent({
 			]),
 			getSettings: (cat: string) =>
 				store.state.settings.default_settings.filter((setting: CourseSettingInfo) => setting.category === cat),
-			getSettingValue: (var_name: string) => {
-				const settings = store.state.settings.course_settings.filter(
-					(setting: CourseSetting) => setting.var === var_name
-				);
-				return settings[0].value;
-			}
+			getSettingValue: (store.getters as { [key: string]: (var_name: string) => CourseSetting['value'] })
+				['settings/get_setting_value']
 		};
 	}
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,23 +3,12 @@ import { InjectionKey } from 'vue';
 import { createStore, Store as VuexStore, useStore as vuexUseStore } from 'vuex';
 import createPersistedState from 'vuex-persistedstate';
 
-import session from './modules/session';
-import { SessionState } from './modules/session';
-
-import users from './modules/users';
-import { UserState } from './modules/users';
-
-import settings from './modules/settings';
-import { SettingsState } from './modules/settings';
-
-import problem_sets from './modules/problem_sets';
-import { ProblemSetState } from './modules/problem_sets';
-
-import courses from './modules/courses';
-import { CourseState } from './modules/courses';
-
-import app_state from './modules/app_state';
-import { AppState } from './modules/app_state';
+import session, { SessionState } from './modules/session';
+import users, { UserState } from './modules/users';
+import settings, { SettingsState } from './modules/settings';
+import problem_sets, { ProblemSetState } from './modules/problem_sets';
+import courses, { CourseState } from './modules/courses';
+import app_state, { AppState } from './modules/app_state';
 
 export interface StateInterface {
 	// Define your own store structure, using submodules if needed

--- a/src/store/modules/settings.ts
+++ b/src/store/modules/settings.ts
@@ -1,7 +1,9 @@
 import { api } from 'boot/axios';
-import { Commit, GetterTree } from 'vuex';
-import { StateInterface } from 'src/store';
-import { CourseSetting, CourseSettingInfo, CourseSettingOption } from 'src/store/models/settings';
+import type { Commit, GetterTree } from 'vuex';
+import type { StateInterface } from 'src/store';
+import type { CourseSettingInfo } from 'src/store/models/settings';
+import { CourseSetting } from 'src/store/models/settings';
+import { CourseSettingOption } from 'src/store/models/settings';
 
 export interface SettingsState {
 	default_settings: Array<CourseSettingInfo>; // this contains default setting and documentation
@@ -18,11 +20,14 @@ function state(): SettingsState {
 type Getters = {
 	default_settings(state: SettingsState): Array<CourseSettingInfo>;
 	course_settings(state: SettingsState): Array<CourseSetting>;
+	get_setting_value(state: SettingsState): (var_name: string) => CourseSetting['value'];
 };
 
 const getters: GetterTree<SettingsState, StateInterface> & Getters = {
 	course_settings: (state) => state.course_settings,
-	default_settings: (state) => state.default_settings
+	default_settings: (state) => state.default_settings,
+	get_setting_value: (state) => (var_name: string) =>
+		state.course_settings.find((setting: CourseSetting) => setting.var === var_name)?.value ?? ''
 };
 
 export default {


### PR DESCRIPTION
Add configuration options to the app i18n object to make it work with the vue composition api.  Also add a fallback locale.

Lazy load the locales from yaml files.  We really don't want to load all languages by default.

Make the language selector show the language names instead of the iso language code.  Note that the displayed language name for the selector is always in its own language regardless of the selected language.  This is how it should be so that users can read the language they want.

Finally, add a few more translations.