### PR TITLE
Add a script to setup the ww3 database for production usage and add support for postgres

### DIFF
--- a/bin/setup_db.pl
+++ b/bin/setup_db.pl
@@ -1,0 +1,106 @@
+#!/usr/bin/env perl
+
+=head1 NAME
+
+setup_db.pl - Create and setup the webwork3 database for production usage.
+
+=head1 SYNOPSIS
+
+setup_db.pl [options]
+
+ Options:
+   -h|--help    Show full help
+
+=head1 DESCRIPTION
+
+Create and setup the webwork3 database for production usage.
+
+Set the values of C<database_dsn>, C<database_user>, and C<database_password> in
+C<conf/webwork3.yml> before running this script.
+
+Note that this script must be run as root to create the database and user for
+mysql or mariadb.
+
+At this time it is assumed that the database host is localhost, and this script
+does not support alternate hosts or ports.
+
+=cut
+
+use warnings;
+use strict;
+use feature 'say';
+
+BEGIN {
+	use File::Basename qw/dirname/;
+	use Cwd qw/abs_path/;
+	$main::webwork3_dir = dirname(dirname(abs_path(__FILE__)));
+}
+
+use lib "$main::webwork3_dir/lib";
+
+use Getopt::Long qw(:config bundling);
+use Pod::Usage;
+use YAML::XS qw/LoadFile/;
+use DBI;
+use DB::Schema;
+use Try::Tiny;
+
+my $showHelp;
+GetOptions('h|help' => \$showHelp);
+pod2usage({ -verbose => 2, -exitval => 0 }) if $showHelp;
+
+# Load the configuration to obtain the database settings.
+my $config = LoadFile("$main::webwork3_dir/conf/webwork3.yml");
+
+my ($database_dbi, $database_type, $database_attr) = $config->{database_dsn} =~ m/([^:]*):([^:]*):([^:;]*).*/;
+
+if ($database_type eq 'mysql') {
+	pod2usage({
+		-message  => 'Root access is required to create a mysql or mariadb databse.',
+		-verbose  => 99,
+		-sections => 'SYNOPSIS|DESCRIPTION',
+		-exitval  => 1
+	})
+		if (getpwuid($<) ne 'root');
+
+	my $database_name = $database_attr =~ s/dbname=//gr;
+
+	try {
+		# Connect to the database as the root user.
+		my $dbh = DBI->connect("$database_dbi:$database_type:", '', '', { PrintError => 0, RaiseError => 1 });
+
+		# List all databases, and if the database does not already exist, then create it.
+		if (!grep { $_->[0] eq $database_name } @{ $dbh->selectall_arrayref('SHOW DATABASES') }) {
+			say "Creating database '$database_name'.";
+			$dbh->do("CREATE DATABASE $database_name");
+		} else {
+			say "Not Creating database '$database_name'.  Database already exists.";
+		}
+
+		# List all users, and if the user does not already exist, then create it.
+		if (!grep { $_->[0] eq $config->{database_user} } @{ $dbh->selectall_arrayref('SELECT user FROM mysql.user') })
+		{
+			say "Creating user '$config->{database_user}'.";
+			$dbh->do("CREATE USER '$config->{database_user}'\@'localhost' "
+					. "IDENTIFIED BY '$config->{database_password}'");
+		} else {
+			say "Not creating user '$config->{database_user}'.  User already exists.";
+		}
+
+		# Grant the necessary permissions to the user.
+		$dbh->do('GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, DROP, LOCK TABLES '
+				. "ON $database_name.* TO '$config->{database_user}'\@'localhost'");
+	} catch {
+		say "ERROR: There was an error communicating with mysql.";
+		exit 1;
+	}
+}
+
+# Connect to the database.
+my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
+
+# Deploy the database as specified by the webwork3 schema.
+say "Setting up the database with dsn '$config->{database_dsn}'";
+$schema->deploy({ add_drop_table => 1 });
+
+1;

--- a/bin/setup_db.pl
+++ b/bin/setup_db.pl
@@ -76,7 +76,7 @@ if ($database_type eq 'mysql') {
 		# List all databases, and if the database does not already exist, then create it.
 		if (!grep { $_->[0] eq $database_name } @{ $dbh->selectall_arrayref('SHOW DATABASES') }) {
 			say "Creating database '$database_name'.";
-			$dbh->do("CREATE DATABASE $database_name");
+			$dbh->do("CREATE DATABASE `$database_name`");
 		} else {
 			say "Not Creating database '$database_name'.  Database already exists.";
 		}
@@ -93,9 +93,10 @@ if ($database_type eq 'mysql') {
 
 		# Grant the necessary permissions to the user.
 		$dbh->do('GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, DROP, LOCK TABLES '
-				. "ON $database_name.* TO '$config->{database_user}'\@'localhost'");
+				. "ON `$database_name`.* TO '$config->{database_user}'\@'localhost'");
 	} catch {
 		say 'ERROR: There was an error communicating with mysql.';
+		say;
 		exit 1;
 	}
 } elsif ($database_type eq 'Pg') {

--- a/conf/webwork3.dist.yml
+++ b/conf/webwork3.dist.yml
@@ -9,17 +9,13 @@ webwork3_home: .
 database_dsn: dbi:SQLite:./t/db/sample_db.sqlite
 # For mysql or mariadb
 #database_dsn: dbi:mysql:dbname=webwork3
+# For postgres
+#database_dsn: dbi:Pg:dbname=webwork3;host=localhost
 
-# Database credentials for mysql, or mariadb.
+# Database credentials for mysql, mariadb, or postgres.
 # These are ignored if the 'sqlite' database is used.
 database_user: webworkWrite
 database_password: password
-
-# Settings for Postgres
-# database_dsn: dbi:Pg:dbname=webwork3;host=localhost
-# If the postgres user is not postgres, assign the user here.
-# postgres_user: user
-
 
 # URL for the Problem Library (OPLv3)
 opl_url: http:/localhost:3030

--- a/conf/webwork3.dist.yml
+++ b/conf/webwork3.dist.yml
@@ -9,8 +9,10 @@ webwork3_home: .
 database_dsn: dbi:SQLite:./t/db/sample_db.sqlite
 # For mysql or mariadb
 #database_dsn: dbi:mysql:dbname=webwork3
+# For postgres
+#database_dsn: dbi:Pg:dbname=webwork3;host=localhost
 
-# Database credentials for mysql or mariadb.
+# Database credentials for mysql, mariadb, or postgres.
 # These are ignored if the 'sqlite' database is used.
 database_user: webworkWrite
 database_password: password

--- a/conf/ww3-dev.dist.yml
+++ b/conf/ww3-dev.dist.yml
@@ -13,10 +13,11 @@ webwork3_home: .
 # For the sqlite database
 database_dsn: dbi:SQLite:./t/db/sample_db.sqlite
 # For mysql or mariadb
-# note: choose a database
 #database_dsn: dbi:mysql:dbname=webwork3_test
+# For postgres
+#database_dsn: dbi:Pg:dbname=webwork3_test;host=localhost
 
-# Database credentials for mysql or mariadb.
+# Database credentials for mysql, mariadb, or postgres.
 # These are ignored if the 'sqlite' database is used.
 database_user: webworkWrite
 database_password: password

--- a/lib/WeBWorK3.pm
+++ b/lib/WeBWorK3.pm
@@ -31,8 +31,10 @@ sub startup ($self) {
 	# Load the database and DBIC plugin
 	$self->plugin(
 		DBIC => {
-			schema =>
-				DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password})
+			schema => DB::Schema->connect(
+				$config->{database_dsn}, $config->{database_user},
+				$config->{database_password}, { quote_names => 1 }
+			)
 		}
 	);
 

--- a/t/db/build_db.pl
+++ b/t/db/build_db.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# This file fills a database with sample data for testing.
+# This file fills a database with sample data from csv files.
 
 use warnings;
 use strict;
@@ -25,13 +25,18 @@ use DB::TestUtils qw/loadCSV/;
 
 my $verbose = 1;
 
-# Load the database
+# Load the configuration for the database settings.
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
 $config_file = "$main::ww3_dir/conf/ww3-dev.dist.yml" unless (-e $config_file);
 my $config = LoadFile($config_file);
-my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
-#$schema->storage->debug(1);  # Print out the SQL commands.
+# Connect to the database.
+my $schema = DB::Schema->connect(
+	$config->{database_dsn},
+	$config->{database_user},
+	$config->{database_password},
+	{ quote_names => 1 }
+);
 
 say "restoring the database with dbi: $config->{database_dsn}" if $verbose;
 


### PR DESCRIPTION
For now the script just creates an empty database.  Eventually it would probably be convenient for the script to also create an admin user.

For postgres things need to be quoted.  Either that or we need to change the name of the table `user`.