### PR TITLE
Fix permissions and require authentication for api routes

### DIFF
--- a/conf/webwork3.dist.yml
+++ b/conf/webwork3.dist.yml
@@ -21,8 +21,8 @@ database_password: password
 opl_url: http:/localhost:3030
 
 # Cookie control settings
-cookie_samesite: "None"
-cookie_secure: true
+cookie_samesite: None
+cookie_secure: 1
 cookie_lifetime: 3600
 
 # Production server configuration

--- a/lib/DB/Schema/ResultSet/UserSet.pm
+++ b/lib/DB/Schema/ResultSet/UserSet.pm
@@ -310,10 +310,7 @@ That is, a C<ProblemSet> (HWSet, Quiz, ...) with UserSet overrides.
 
 =cut
 
-use Data::Dumper;
-
 sub addUserSet ($self, %args) {
-	print Dumper \%args;
 	my $problem_set = $self->rs("ProblemSet")->getProblemSet(info => $args{params}, as_result_set => 1);
 	my $course_user = $self->rs("User")->getCourseUser(info => $args{params}, as_result_set => 1);
 

--- a/lib/WeBWorK3.pm
+++ b/lib/WeBWorK3.pm
@@ -41,8 +41,8 @@ sub startup ($self) {
 	# Load the authentication plugin
 	$self->plugin(
 		Authentication => {
-			load_user     => sub ($app, $uid) { $self->load_account($uid) },
-			validate_user => sub ($c,   $u, $p, $e) { $self->validate($u, $p) ? $u : undef; }
+			load_user     => sub ($app, $uid) { return $self->load_account($uid); },
+			validate_user => sub ($c,   $u, $p, $e) { return $self->validate($u, $p); }
 		}
 	);
 
@@ -53,11 +53,9 @@ sub startup ($self) {
 	$self->sessions->samesite($config->{cookie_samesite});
 	$self->sessions->secure($config->{cookie_secure});
 
-	# Load permissions and set up some helpers for dealing with permissions.
+	# Load permissions and set up a helper for dealing with permissions.
 	$perm_table = LoadFile("$ENV{WW3_ROOT}/conf/permissions.yaml");
-
-	$self->helper(perm_table         => sub ($c) { return $perm_table; });
-	$self->helper(ignore_permissions => sub ($c) { return $config->{ignore_permissions}; });
+	$self->helper(perm_table => sub ($c) { return $perm_table; });
 
 	# Handle all api route exceptions
 	$self->hook(around_dispatch => $WeBWorK3::Hooks::exception_handler);
@@ -77,12 +75,12 @@ sub startup ($self) {
 }
 
 sub load_account ($self, $user_id) {
-	my $user = $self->schema->resultset("User")->getGlobalUser(info => { username => $user_id });
-	return $user;
+	return $self->schema->resultset("User")->getGlobalUser(info => { username => $user_id });
 }
 
 sub validate ($self, $user, $password) {
-	return $self->schema->resultset("User")->authenticate($user, $password);
+	return $user if ($self->schema->resultset("User")->authenticate($user, $password));
+	return;
 }
 
 sub loginRoutes ($self) {
@@ -92,7 +90,8 @@ sub loginRoutes ($self) {
 }
 
 sub coursesRoutes ($self) {
-	my $course_routes = $self->routes->any('/webwork3/api/courses')->to(controller => 'Course');
+	my $course_routes =
+		$self->routes->any('/webwork3/api/courses')->requires(authenticated => 1)->to(controller => 'Course');
 	$course_routes->get('/')->to(action => 'getCourses');
 	$course_routes->get('/:course_id')->to(action => 'getCourse');
 	$course_routes->put('/:course_id')->to(action => 'updateCourse');
@@ -102,7 +101,7 @@ sub coursesRoutes ($self) {
 }
 
 sub userRoutes ($self) {
-	my $user_routes = $self->routes->any('/webwork3/api/users')->to(controller => 'User');
+	my $user_routes = $self->routes->any('/webwork3/api/users')->requires(authenticated => 1)->to(controller => 'User');
 	$user_routes->get('/')->to(action => 'getGlobalUsers');
 	$user_routes->post('/')->to(action => 'addGlobalUser');
 	$user_routes->get('/:user')->to(action => 'getGlobalUser');
@@ -111,25 +110,29 @@ sub userRoutes ($self) {
 	$user_routes->get('/:user_id/courses')->to(action => 'getUserCourses');
 	# This is needed to get global users as instructor permission.  Need to have
 	# the parameter course_id.
-	$self->routes->any('/webwork3/api/courses/:course_id/users/:user/exists')->to('User#getGlobalUser');
+	$self->routes->any('/webwork3/api/courses/:course_id/users/:user/exists')->requires(authenticated => 1)
+		->to('User#getGlobalUser');
 	return;
 }
 
 sub courseUserRoutes ($self) {
-	my $course_user_routes = $self->routes->any('/webwork3/api/courses/:course_id/users')->to(controller => 'User');
+	my $course_user_routes = $self->routes->any('/webwork3/api/courses/:course_id/users')->requires(authenticated => 1)
+		->to(controller => 'User');
 	$course_user_routes->get('/')->to(action => 'getCourseUsers');
 	$course_user_routes->post('/')->to(action => 'addCourseUser');
 	$course_user_routes->get('/:user_id')->to(action => 'getCourseUser');
 	$course_user_routes->put('/:user_id')->to(action => 'updateCourseUser');
 	$course_user_routes->delete('/:user_id')->to(action => 'deleteCourseUser');
-	$self->routes->any('/webwork3/api/courses/:course_id/courseusers')->to('User#getMergedCourseUsers');
+	$self->routes->any('/webwork3/api/courses/:course_id/courseusers')->requires(authenticated => 1)
+		->to('User#getMergedCourseUsers');
 	return;
 }
 
 sub problemSetRoutes ($self) {
-	$self->routes->get('/webwork3/api/sets')->to("ProblemSet#getProblemSets");
+	$self->routes->get('/webwork3/api/sets')->requires(authenticated => 1)->to("ProblemSet#getProblemSets");
 	my $problem_set_routes =
-		$self->routes->any('/webwork3/api/courses/:course_id/sets')->to(controller => 'ProblemSet');
+		$self->routes->any('/webwork3/api/courses/:course_id/sets')->requires(authenticated => 1)
+		->to(controller => 'ProblemSet');
 	$problem_set_routes->get('/')->to(action => 'getProblemSets');
 	$problem_set_routes->get('/:set_id')->to(action => 'getProblemSet');
 	$problem_set_routes->put('/:set_id')->to(action => 'updateProblemSet');
@@ -143,7 +146,8 @@ sub problemSetRoutes ($self) {
 }
 
 sub problemRoutes ($self) {
-	my $problem_routes = $self->routes->any('/webwork3/api/courses/:course_id')->to(controller => 'Problem');
+	my $problem_routes = $self->routes->any('/webwork3/api/courses/:course_id')->requires(authenticated => 1)
+		->to(controller => 'Problem');
 	$problem_routes->get('/problems')->to(action => 'getAllProblems');
 	$problem_routes->post('/sets/:set_id/problems')->to(action => 'addProblem');
 	$problem_routes->put('/sets/:set_id/problems/:problem_id')->to(action => 'updateProblem');
@@ -153,14 +157,17 @@ sub problemRoutes ($self) {
 }
 
 sub settingsRoutes ($self) {
-	$self->routes->get('/webwork3/api/default_settings')->to("Settings#getDefaultCourseSettings");
-	$self->routes->get('/webwork3/api/courses/:course_id/settings')->to("Settings#getCourseSettings");
-	$self->routes->put('/webwork3/api/courses/:course_id/setting')->to("Settings#updateCourseSetting");
+	$self->routes->get('/webwork3/api/default_settings')->requires(authenticated => 1)
+		->to("Settings#getDefaultCourseSettings");
+	$self->routes->get('/webwork3/api/courses/:course_id/settings')->requires(authenticated => 1)
+		->to("Settings#getCourseSettings");
+	$self->routes->put('/webwork3/api/courses/:course_id/setting')->requires(authenticated => 1)
+		->to("Settings#updateCourseSetting");
 	return;
 }
 
 sub utilityRoutes ($self) {
-	$self->routes->post('/webwork3/api/client-logs')->to("Logger#clientLog");
+	$self->routes->post('/webwork3/api/client-logs')->requires(authenticated => 1)->to("Logger#clientLog");
 	return;
 }
 

--- a/t/mojolicious/004_course_users.t
+++ b/t/mojolicious/004_course_users.t
@@ -13,10 +13,6 @@ BEGIN {
 
 use lib "$main::ww3_dir/lib";
 
-use Getopt::Long;
-my $TEST_PERMISSIONS;
-GetOptions("perm" => \$TEST_PERMISSIONS);
-
 use DB::Schema;
 use Clone qw/clone/;
 use YAML::XS qw/LoadFile/;
@@ -31,20 +27,11 @@ my $config = clone(LoadFile($config_file));
 # Connect to the database.
 my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
-my $t;
+my $t = Test::Mojo->new(WeBWorK3 => $config);
 
-if ($TEST_PERMISSIONS) {
-	$config->{ignore_permissions} = 0;
-	$t = Test::Mojo->new(WeBWorK3 => $config);
-
-	$t->post_ok('/webwork3/api/username' => json => { email => 'admin@google.com', password => 'admin' })
-		->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
-		->json_is('/user/user_id' => 1)->json_is('/user/is_admin' => 1);
-
-} else {
-	$config->{ignore_permissions} = 1;
-	$t = Test::Mojo->new(WeBWorK3 => $config);
-}
+$t->post_ok('/webwork3/api/login' => json => { username => 'admin', password => 'admin' })->status_is(200)
+	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)->json_is('/user/user_id' => 1)
+	->json_is('/user/is_admin' => 1);
 
 # Remove the user "maggie" if it exists in the database.
 my $maggie = $schema->resultset("User")->find({ username => "maggie" });
@@ -110,10 +97,9 @@ $t->put_ok("/webwork3/api/courses/1/users/$new_user_id" => json => { recitation 
 	->json_is('/exception' => 'DB::Exception::UserNotInCourse');
 
 # Try to add a user without a username.
-my $another_new_user = { username_name => "this is the wrong field" };
-
-$t->post_ok("/webwork3/api/courses/1/users" => json => $another_new_user)->status_is(250, "status for exception")
-	->content_type_is('application/json;charset=UTF-8')->json_is('/exception' => 'DB::Exception::ParametersNeeded');
+$t->post_ok("/webwork3/api/courses/1/users" => json => { username_name => "this is the wrong field" })
+	->status_is(250, "status for exception")->content_type_is('application/json;charset=UTF-8')
+	->json_is('/exception' => 'DB::Exception::ParametersNeeded');
 
 # Try to delete a user that is not found.
 $t->delete_ok("/webwork3/api/courses/1/users/99")->status_is(250, "status for exception")
@@ -126,22 +112,18 @@ $t->delete_ok("/webwork3/api/courses/1/users/$new_user_id")->status_is(250, "sta
 $t->delete_ok("/webwork3/api/courses/2/users/$new_user_id")->status_is(200)
 	->content_type_is('application/json;charset=UTF-8')->json_is('/user_id' => $new_user_id);
 
-if ($TEST_PERMISSIONS) {
-	print "HERE!!!\n";
-	$t->post_ok("/webwork3/api/logout")->status_is(200)->json_is('/logged_in' => 0);
+# Logout of the admin user account.
+$t->post_ok("/webwork3/api/logout")->status_is(200)->json_is('/logged_in' => 0);
 
-	# Check that a non_admin user has proper access.
-	my @all_users   = $schema->resultset("User")->getCourseUsers(info => { course_id => 1 });
-	my @instructors = grep { $_->{role} eq 'instructor' } @all_users;
+# Check that a non_admin user has proper access.
+my @instructors =
+	grep { $_->{role} eq 'instructor' } $schema->resultset("User")->getCourseUsers(info => { course_id => 1 });
+my $instructor = $schema->resultset("User")->getGlobalUser(info => { user_id => $instructors[0]{user_id} });
 
-	$t->post_ok(
-		"/webwork3/api/username" => json => {
-			email    => $instructors[0]->{email},
-			password => $instructors[0]->{username}
-		}
-	)->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1);
+$t->post_ok(
+	"/webwork3/api/login" => json => { username => $instructor->{username}, password => $instructor->{username} })
+	->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1);
 
-	$t->get_ok('/webwork3/api/courses/1/users')->status_is(200)->content_type_is('application/json;charset=UTF-8');
-}
+$t->get_ok('/webwork3/api/courses/1/users')->status_is(200)->content_type_is('application/json;charset=UTF-8');
 
 done_testing;

--- a/t/mojolicious/005_problem_sets.t
+++ b/t/mojolicious/005_problem_sets.t
@@ -15,10 +15,6 @@ BEGIN {
 
 use lib "$main::ww3_dir/lib";
 
-use Getopt::Long;
-my $TEST_PERMISSIONS;
-GetOptions("perm" => \$TEST_PERMISSIONS);
-
 use DB::Schema;
 use Clone qw/clone/;
 use YAML::XS qw/LoadFile/;
@@ -37,19 +33,11 @@ my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croa
 my $schema =
 	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
-my $t;
+my $t = Test::Mojo->new(WeBWorK3 => $config);
 
-if ($TEST_PERMISSIONS) {
-	$config->{ignore_permissions} = 0;
-	$t = Test::Mojo->new(WeBWorK3 => $config);
-
-	$t->post_ok('/webwork3/api/username' => json => { email => 'admin@google.com', password => 'admin' })
-		->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
-		->json_is('/user/user_id' => 1)->json_is('/user/is_admin' => 1);
-} else {
-	$config->{ignore_permissions} = 1;
-	$t = Test::Mojo->new(WeBWorK3 => $config);
-}
+$t->post_ok('/webwork3/api/login' => json => { username => 'admin', password => 'admin' })->status_is(200)
+	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)->json_is('/user/user_id' => 1)
+	->json_is('/user/is_admin' => 1);
 
 # Load the homework sets.
 my @hw_sets = loadCSV("$main::ww3_dir/t/db/sample_data/hw_sets.csv");
@@ -111,21 +99,18 @@ $t->delete_ok("/webwork3/api/courses/2/sets/$new_set_id")->content_type_is('appl
 $t->delete_ok("/webwork3/api/courses/1/sets/6")->content_type_is('application/json;charset=UTF-8')
 	->json_is('/exception' => 'DB::Exception::SetNotInCourse');
 
-if ($TEST_PERMISSIONS) {
-	$t->post_ok("/webwork3/api/logout")->status_is(200)->json_is('/logged_in' => 0);
+# Logout of the admin user account.
+$t->post_ok("/webwork3/api/logout")->status_is(200)->json_is('/logged_in' => 0);
 
-	# Check that a non-admin user has proper access.
-	my @all_users   = $schema->resultset("User")->getCourseUsers(info => { course_id => 1 });
-	my @instructors = grep { $_->{role} eq 'instructor' } @all_users;
+# Check that a non-admin user has proper access.
+my @instructors =
+	grep { $_->{role} eq 'instructor' } $schema->resultset("User")->getCourseUsers(info => { course_id => 1 });
+my $instructor = $schema->resultset("User")->getGlobalUser(info => { user_id => $instructors[0]{user_id} });
 
-	$t->post_ok(
-		"/webwork3/api/username" => json => {
-			email    => $instructors[0]->{email},
-			password => $instructors[0]->{username}
-		}
-	)->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1);
+$t->post_ok(
+	"/webwork3/api/login" => json => { username => $instructor->{username}, password => $instructor->{username} })
+	->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1);
 
-	$t->get_ok('/webwork3/api/courses/1/sets')->status_is(200)->content_type_is('application/json;charset=UTF-8');
-}
+$t->get_ok('/webwork3/api/courses/1/sets')->status_is(200)->content_type_is('application/json;charset=UTF-8');
 
 done_testing;

--- a/t/mojolicious/006_quizzes.t
+++ b/t/mojolicious/006_quizzes.t
@@ -15,10 +15,6 @@ BEGIN {
 
 use lib "$main::ww3_dir/lib";
 
-use Getopt::Long;
-my $TEST_PERMISSIONS;
-GetOptions("perm" => \$TEST_PERMISSIONS);
-
 use DB::Schema;
 use Clone qw/clone/;
 use YAML::XS qw/LoadFile/;
@@ -36,20 +32,11 @@ my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croa
 # Connect to the database.
 my $schema = DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
-my $t;
+my $t = Test::Mojo->new(WeBWorK3 => $config);
 
-if ($TEST_PERMISSIONS) {
-	$config->{ignore_permissions} = 0;
-	$t = Test::Mojo->new(WeBWorK3 => $config);
-
-	$t->post_ok('/webwork3/api/username' => json => { email => 'admin@google.com', password => 'admin' })
-		->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
-		->json_is('/user/user_id' => 1)->json_is('/user/is_admin' => 1);
-
-} else {
-	$config->{ignore_permissions} = 1;
-	$t = Test::Mojo->new(WeBWorK3 => $config);
-}
+$t->post_ok('/webwork3/api/login' => json => { username => 'admin', password => 'admin' })->status_is(200)
+	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)->json_is('/user/user_id' => 1)
+	->json_is('/user/is_admin' => 1);
 
 # Load the quizzes.
 my @quizzes = loadCSV("$main::ww3_dir/t/db/sample_data/quizzes.csv");


### PR DESCRIPTION
Remove the ignore_permissions option and use permissions in unit test.  The permissions are fixed so that they actually work.

Also require authentication to access all api routes except the login and logout routes.

Fix the cookie settings in the conf file.  The samesite setting does not need the quotes, and the secure setting needs to be a numeric 0 or 1.  The string true did work because that is truthy in perl.  However, it is misleading because the string false is also truthy.