### PR TITLE
Lock the perltidy version in the linter workflow.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -81,7 +81,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install dependencies
-        run: cpanm -n Perl::Tidy
+        run: cpanm -n Perl::Tidy@20220217
       - name: perltidy --version
         run: perltidy --version
       - name: Run perltidy


### PR DESCRIPTION
The latest version of perltidy changes to much.