### PR TITLE
Add two new perltidy options.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -81,7 +81,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install dependencies
-        run: cpanm -n Perl::Tidy@20220217
+        run: cpanm -n Perl::Tidy@20220613
       - name: perltidy --version
         run: perltidy --version
       - name: Run perltidy

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -19,3 +19,5 @@
 -nbot   # No line break on ternary
 -nlop   # No logical padding (this causes mixed tabs and spaces)
 -wn     # Weld nested containers
+-xci    # Extended continuation indentation
+-vxl='q' # No vertical alignment of qw quotes

--- a/lib/DB/Schema/ResultSet/ProblemPool.pm
+++ b/lib/DB/Schema/ResultSet/ProblemPool.pm
@@ -119,9 +119,9 @@ sub addProblemPool ($self, %args) {
 	DB::Exception::PoolAlreadyInCourse->throw(
 		message => 'The problem pool '
 			. (
-			$args{info}->{pool_name} || $args{params}->{pool_name}
-			? ' with name ' . ($args{info}->{pool_name} // $args{params}->{pool_name})
-			: ' with id ' . $args{info}->{problem_pool_id}
+				$args{info}->{pool_name} || $args{params}->{pool_name}
+				? ' with name ' . ($args{info}->{pool_name} // $args{params}->{pool_name})
+				: ' with id ' . $args{info}->{problem_pool_id}
 			)
 			. " is already defined in the course $course->course_name"
 	) if defined($existing_pool);
@@ -154,7 +154,9 @@ sub updateProblemPool ($self, %args) {
 	DB::Excpetion::PoolNotInCourse->throw(
 		message => 'The problem pool '
 			. (
-			$args{info}->{pool_name} ? " named $args{info}->{pool_name}" : " with id $args{info}->{problem_pool_id}"
+				$args{info}->{pool_name}
+				? " named $args{info}->{pool_name}"
+				: " with id $args{info}->{problem_pool_id}"
 			)
 			. ' is not in the course '
 			. $args{info}->{course_name} ? " named '$args{info}->{course_name}'" : " with id $args{info}->{course_id}"

--- a/lib/DB/Schema/ResultSet/SetProblem.pm
+++ b/lib/DB/Schema/ResultSet/SetProblem.pm
@@ -169,9 +169,9 @@ sub getSetProblem ($self, %args) {
 	DB::Exception::SetProblemNotFound->throw(
 		message => 'the problem with '
 			. (
-			$args{info}->{problem_number}
-			? 'problem number ' . $args{info}->{problem_number}
-			: 'set_problem id: ' . $args{info}->{set_problem_id}
+				$args{info}->{problem_number}
+				? 'problem number ' . $args{info}->{problem_number}
+				: 'set_problem id: ' . $args{info}->{set_problem_id}
 			)
 			. ' is not found for set: '
 			. $problem_set->set_name

--- a/lib/DB/Schema/ResultSet/UserProblem.pm
+++ b/lib/DB/Schema/ResultSet/UserProblem.pm
@@ -413,9 +413,9 @@ sub updateUserProblem ($self, %args) {
 		$args{info}->{user_problem_id}
 		? $self->find({ user_problem_id => $args{info}->{user_problem_id} })
 		: $self->getUserProblem(
-		info          => $args{info},
-		skip_throw    => 1,
-		as_result_set => 1
+			info          => $args{info},
+			skip_throw    => 1,
+			as_result_set => 1
 		);
 
 	DB::Exception::UserProblemNotFound->throw(message => 'The user '
@@ -481,9 +481,9 @@ sub deleteUserProblem ($self, %args) {
 		$args{info}->{user_problem_id}
 		? $self->find({ user_problem_id => $args{info}->{user_problem_id} })
 		: $self->getUserProblem(
-		info          => $args{info},
-		skip_throw    => 1,
-		as_result_set => 1
+			info          => $args{info},
+			skip_throw    => 1,
+			as_result_set => 1
 		);
 
 	DB::Exception::UserProblemNotFound->throw(message => 'The user '

--- a/t/mojolicious/001_login.t
+++ b/t/mojolicious/001_login.t
@@ -25,29 +25,29 @@ my $t = Test::Mojo->new('WeBWorK3' => LoadFile($config_file));
 # Test missing credentials
 $t->post_ok('/webwork3/api/login')->status_is(500, 'error status')->content_type_is('application/json;charset=UTF-8')
 	->json_is(
-	'' => {
-		exception => 'DB::Exception::ParametersNeeded',
-		message   => 'You must pass exactly one of user_id, username, email.'
-	},
-	'no credentials'
+		'' => {
+			exception => 'DB::Exception::ParametersNeeded',
+			message   => 'You must pass exactly one of user_id, username, email.'
+		},
+		'no credentials'
 	);
 
 # Test valid username and password
 $t->post_ok('/webwork3/api/login' => json => { username => 'lisa', password => 'lisa' })->status_is(200)
 	->content_type_is('application/json;charset=UTF-8')->json_is(
-	'' => {
-		logged_in => 1,
-		user      => {
-			email      => 'lisa@google.com',
-			first_name => 'Lisa',
-			is_admin   => 0,
-			last_name  => 'Simpson',
-			student_id => '23',
-			user_id    => 3,
-			username   => 'lisa'
-		}
-	},
-	'valid credentials'
+		'' => {
+			logged_in => 1,
+			user      => {
+				email      => 'lisa@google.com',
+				first_name => 'Lisa',
+				is_admin   => 0,
+				last_name  => 'Simpson',
+				student_id => '23',
+				user_id    => 3,
+				username   => 'lisa'
+			}
+		},
+		'valid credentials'
 	);
 
 # Test logout
@@ -62,11 +62,11 @@ $t->post_ok('/webwork3/api/logout')->status_is(200)->content_type_is('applicatio
 # Test for a bad password
 $t->post_ok('/webwork3/api/login' => json => { username => 'lisa', password => 'wrong_password' })->status_is(200)
 	->content_type_is('application/json;charset=UTF-8')->json_is(
-	'' => {
-		logged_in => 0,
-		message   => 'Incorrect username or password.'
-	},
-	'invalid credentials'
+		'' => {
+			logged_in => 0,
+			message   => 'Incorrect username or password.'
+		},
+		'invalid credentials'
 	);
 
 done_testing;


### PR DESCRIPTION
First add the extended continuation indentation option. I added this to
the webwork2 and pg .perltidyrc files, and it does a better job of
indenting for nested structures.  This rule responsible for the changes
to the other files in this pull request.

Second add the option to disable vertical alignment of qw quotes.  Since
this option is added, the workflow version of perltidy can now be
allowed to increase.  I left the lock though, and just moved it to the
newest version.