### PR TITLE
Add the eslint rule `'template-curly-spacing': ['error', 'never']`.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ const baseRules = {
 	'no-trailing-spaces': ['error'],
 	'space-in-parens': ['error', 'never'],
 	'object-curly-spacing': ['error', 'always'],
+	'template-curly-spacing': ['error', 'never'],
 	'comma-spacing': ['error', { before: false, after: true }],
 	'semi': ['error', 'always'],
 	'generator-star-spacing': 'off',


### PR DESCRIPTION
This enforces that there are no spaces inside curly brackes in a template literal, and these are automatically fixable when eslint is run!