### PR TITLE
switch the logger to loglevel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"core-js": "^3.6.5",
 				"jquery": "^3.6.0",
 				"jsdoc": "^3.6.7",
+				"loglevel": "^1.8.0",
 				"mathjax": "^3.2.0",
 				"node-polyfill-webpack-plugin": "^1.1.4",
 				"papaparse": "^5.3.1",
@@ -22,8 +23,7 @@
 				"quasar": "^2.3.1",
 				"setimmediate": "^1.0.5",
 				"vue-draggable-next": "^2.1.1",
-				"vue-i18n": "^9.1.7",
-				"winston": "^3.3.3"
+				"vue-i18n": "^9.1.7"
 			},
 			"devDependencies": {
 				"@babel/eslint-parser": "^7.13.14",
@@ -1801,24 +1801,6 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
-		},
-		"node_modules/@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
-		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-			"dependencies": {
-				"colorspace": "1.1.x",
-				"enabled": "2.0.x",
-				"kuler": "^2.0.0"
-			}
 		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "0.4.3",
@@ -4380,7 +4362,8 @@
 		"node_modules/async": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+			"dev": true
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -5504,19 +5487,11 @@
 			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
-		"node_modules/color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"dependencies": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -5524,16 +5499,8 @@
 		"node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"node_modules/color-string": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"node_modules/colord": {
 			"version": "2.9.2",
@@ -5546,15 +5513,6 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
 			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
 			"dev": true
-		},
-		"node_modules/colorspace": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-			"dependencies": {
-				"color": "^3.1.3",
-				"text-hex": "1.0.x"
-			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -7000,11 +6958,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
-		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -7960,11 +7913,6 @@
 				"bser": "2.1.1"
 			}
 		},
-		"node_modules/fecha": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-			"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
-		},
 		"node_modules/figures": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -8162,11 +8110,6 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
 			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
-		},
-		"node_modules/fn.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.14.9",
@@ -9789,6 +9732,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -11983,11 +11927,6 @@
 			"integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
 			"dev": true
 		},
-		"node_modules/kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-		},
 		"node_modules/launch-editor": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.3.0.tgz",
@@ -12322,16 +12261,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/logform": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
-			"integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
-			"dependencies": {
-				"@colors/colors": "1.5.0",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
+		"node_modules/loglevel": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+			"integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+			"engines": {
+				"node": ">= 0.6.0"
+			},
+			"funding": {
+				"type": "tidelift",
+				"url": "https://tidelift.com/funding/github/npm/loglevel"
 			}
 		},
 		"node_modules/longest-streak": {
@@ -12857,7 +12796,8 @@
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"node_modules/multicast-dns": {
 			"version": "6.2.3",
@@ -13222,14 +13162,6 @@
 			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
-			}
-		},
-		"node_modules/one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"dependencies": {
-				"fn.name": "1.x.x"
 			}
 		},
 		"node_modules/onetime": {
@@ -15567,14 +15499,6 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-			"integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -15902,19 +15826,6 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
-		"node_modules/simple-swizzle/node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-		},
 		"node_modules/sirv": {
 			"version": "1.0.19",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
@@ -16139,14 +16050,6 @@
 			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
 			"dev": true
-		},
-		"node_modules/stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/stack-utils": {
 			"version": "2.0.5",
@@ -17065,11 +16968,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -17211,11 +17109,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/triple-beam": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
 		},
 		"node_modules/trough": {
 			"version": "1.0.5",
@@ -18764,39 +18657,6 @@
 			"integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
 			"dev": true
 		},
-		"node_modules/winston": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.6.0.tgz",
-			"integrity": "sha512-9j8T75p+bcN6D00sF/zjFVmPp+t8KMPB1MzbbzYjeN9VWxdsYnTB40TkbNUEXAmILEfChMvAMgidlX64OG3p6w==",
-			"dependencies": {
-				"@dabh/diagnostics": "^2.0.2",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.5.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston-transport": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
-			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 6.4.0"
-			}
-		},
 		"node_modules/word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -20233,21 +20093,6 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
-		},
-		"@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
-		},
-		"@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-			"requires": {
-				"colorspace": "1.1.x",
-				"enabled": "2.0.x",
-				"kuler": "^2.0.0"
-			}
 		},
 		"@eslint/eslintrc": {
 			"version": "0.4.3",
@@ -22305,7 +22150,8 @@
 		"async": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -23153,19 +22999,11 @@
 			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
-		"color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-			"requires": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
-			}
-		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -23173,16 +23011,8 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"color-string": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"colord": {
 			"version": "2.9.2",
@@ -23195,15 +23025,6 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
 			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
 			"dev": true
-		},
-		"colorspace": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-			"requires": {
-				"color": "^3.1.3",
-				"text-hex": "1.0.x"
-			}
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -24310,11 +24131,6 @@
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
 			"dev": true
 		},
-		"enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
-		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -25041,11 +24857,6 @@
 				"bser": "2.1.1"
 			}
 		},
-		"fecha": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-			"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
-		},
 		"figures": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -25195,11 +25006,6 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
 			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
-		},
-		"fn.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
 		},
 		"follow-redirects": {
 			"version": "1.14.9",
@@ -26322,7 +26128,8 @@
 		"is-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true
 		},
 		"is-string": {
 			"version": "1.0.7",
@@ -27958,11 +27765,6 @@
 			"integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
 			"dev": true
 		},
-		"kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-		},
 		"launch-editor": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.3.0.tgz",
@@ -28247,17 +28049,10 @@
 				"wrap-ansi": "^6.2.0"
 			}
 		},
-		"logform": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
-			"integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
-			"requires": {
-				"@colors/colors": "1.5.0",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
-			}
+		"loglevel": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+			"integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
 		},
 		"longest-streak": {
 			"version": "2.0.4",
@@ -28650,7 +28445,8 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -28920,14 +28716,6 @@
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
-			}
-		},
-		"one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"requires": {
-				"fn.name": "1.x.x"
 			}
 		},
 		"onetime": {
@@ -30622,11 +30410,6 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
-		"safe-stable-stringify": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-			"integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
-		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -30887,21 +30670,6 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
-		"simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"requires": {
-				"is-arrayish": "^0.3.1"
-			},
-			"dependencies": {
-				"is-arrayish": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-				}
-			}
-		},
 		"sirv": {
 			"version": "1.0.19",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
@@ -31094,11 +30862,6 @@
 			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
 			"dev": true
-		},
-		"stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
 		},
 		"stack-utils": {
 			"version": "2.0.5",
@@ -31769,11 +31532,6 @@
 				"minimatch": "^3.0.4"
 			}
 		},
-		"text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -31887,11 +31645,6 @@
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
 			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
 			"dev": true
-		},
-		"triple-beam": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
 		},
 		"trough": {
 			"version": "1.0.5",
@@ -33018,33 +32771,6 @@
 			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
 			"integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
 			"dev": true
-		},
-		"winston": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.6.0.tgz",
-			"integrity": "sha512-9j8T75p+bcN6D00sF/zjFVmPp+t8KMPB1MzbbzYjeN9VWxdsYnTB40TkbNUEXAmILEfChMvAMgidlX64OG3p6w==",
-			"requires": {
-				"@dabh/diagnostics": "^2.0.2",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.5.0"
-			}
-		},
-		"winston-transport": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
-			"requires": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
-				"triple-beam": "^1.3.0"
-			}
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"core-js": "^3.6.5",
 		"jquery": "^3.6.0",
 		"jsdoc": "^3.6.7",
+		"loglevel": "^1.8.0",
 		"mathjax": "^3.2.0",
 		"node-polyfill-webpack-plugin": "^1.1.4",
 		"papaparse": "^5.3.1",
@@ -28,8 +29,7 @@
 		"quasar": "^2.3.1",
 		"setimmediate": "^1.0.5",
 		"vue-draggable-next": "^2.1.1",
-		"vue-i18n": "^9.1.7",
-		"winston": "^3.3.3"
+		"vue-i18n": "^9.1.7"
 	},
 	"devDependencies": {
 		"@babel/eslint-parser": "^7.13.14",

--- a/src/stores/set_problems.ts
+++ b/src/stores/set_problems.ts
@@ -138,7 +138,7 @@ export const useSetProblemStore = defineStore('set_problems', {
 				catch((e: Error) =>
 					logger.error(`[addSetProblem] ${JSON.stringify(prob)} failed with ${e.message}`));
 
-			const new_problem = new SetProblem(response.data as ParseableSetProblem);
+			const new_problem = new SetProblem(response as ParseableSetProblem);
 			this.set_problems.push(new_problem);
 			return new_problem;
 		},


### PR DESCRIPTION
This switches the logger from Winston to log level.  A couple of reasons for this:
- Winston is quite heavyweight and was designed to be a node/backend logger, not a client-side one. 
- I've been trying to switch webwork3 to using vite instead of webpack and Winston was not working with vite and didn't seem like there is much to do to switch.

The current version of this 
1. logs to the console using a number of levels (info, trace, debug, warn, error).  This was a drop-in replacement for winston
2. for errors the error is sent to the backend for logging. 

The code for doing the posting to the server uses the built-in axios.api methods and is quite flexible if we would like to include a warn level, etc.  

Also, I haven't yet tested the production version of webwork3 for testing. 

Wanted to put this out there for feedback. 