### PR TITLE
Adapt the unit test action to not use a docker image.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -56,7 +56,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Super-Linter
-        uses: github/super-linter@v4.8.1
+        uses: github/super-linter@v4.9.5
 
         env:
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,18 +1,73 @@
+---
 name: Unit Tests and Coverage
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
-    # If we are going to use a prebuilt image like this we need a webwork repository on docker hub
-    container: drgrice1/webwork3
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout webwork3 source code
+        uses: actions/checkout@v3
+
+      # Disabling these things speeds up the setup considerably, and they are not needed for the throw away machine.
+      - name: Disable man-db and initramfs updates
+        run: |
+          sudo sed -i 's/yes/no/g' /etc/initramfs-tools/update-initramfs.conf
+          sudo rm -f /var/lib/man-db/auto-update
+
+      - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          DEBCONF_NONINTERACTIVE_SEEN: true
+          DEBCONF_NOWARNINGS: yes
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy --no-install-recommends --no-install-suggests \
+            cpanminus \
+            libarray-utils-perl \
+            libcanary-stability-perl \
+            libcapture-tiny-perl \
+            libclass-accessor-lite-perl \
+            libclone-perl \
+            libcpanel-json-xs-perl \
+            libcrypt-ssleay-perl \
+            libdata-dump-perl \
+            libdatetime-format-strptime-perl \
+            libdbd-sqlite3-perl \
+            libdbix-class-inflatecolumn-serializer-perl \
+            libdbix-class-perl \
+            libdbix-dbschema-perl \
+            libdevel-cover-perl \
+            libexception-class-perl \
+            libextutils-config-perl \
+            libextutils-helpers-perl \
+            libextutils-installpaths-perl \
+            libfurl-perl \
+            libhttp-parser-xs-perl \
+            libimporter-perl \
+            libio-socket-ssl-perl \
+            liblist-moreutils-perl \
+            libmodule-build-tiny-perl \
+            libmojolicious-perl \
+            libmojolicious-plugin-authentication-perl \
+            libnet-ssleay-perl \
+            libsql-translator-perl \
+            libtest-exception-perl \
+            libtest-harness-perl \
+            libtext-csv-perl \
+            libtry-tiny-perl \
+            libyaml-libyaml-perl
+          cpanm --sudo --notest \
+            DBIx::Class::DynamicSubclass \
+            Mojolicious::Plugin::DBIC \
+            Mojolicious::Plugin::NotYAMLConfig \
+            Devel::Cover::Report::Codecov
+
       - name: Run perl unit tests
         env:
           HARNESS_PERL_SWITCHES: -MDevel::Cover
@@ -20,24 +75,20 @@ jobs:
           perl t/db/build_db.pl
           prove -r t
 
-      # we probably don'te need to upload the codecov data
-      # - uses: actions/upload-artifact@v2
-      #   with:
-      #     name: coverage-report
-      #     path: cover_db/
-
       - name: Push coverage analysis
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: cover -report codecov
 
-      # Install node (for npm) and use it to install eslint and stylelint dependencies.
-      - name: Use Node.js
-        uses: actions/setup-node@v2
+      # Install node (for npm).
+      - name: Set up node
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
+
       - name: Install Dependencies
         run: npm ci
+
       - name: Run typescript (client-side) tests
         run: npm run test

--- a/docker/webwork3.dockerfile
+++ b/docker/webwork3.dockerfile
@@ -1,46 +1,61 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
-# the following are needed to make sure the timezone packages don't ask for your timezone.
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV DEBCONF_NOWARNINGS yes
 ENV HARNESS_PERL_SWITCHES -MDevel::Cover
 
 RUN apt-get update && \
 	apt-get install -qy --no-install-recommends --no-install-suggests \
-		build-essential=12.8ubuntu1 \
-		ca-certificates=20210119~20.04.1 \
-		cpanminus=1.7044-1 \
-		git=1:2.25.1-1ubuntu3.1 \
-		libarray-utils-perl=0.5-1 \
-		libclone-perl=0.43-2 \
-		libcrypt-ssleay-perl=0.73.06-1build3 \
-		libdata-dump-perl=1.23-1 \
-		libdatetime-format-strptime-perl=1.7600-1 \
-		libdbd-mysql-perl=4.050-3 \
-		libdbd-sqlite3-perl=1.64-1build1 \
-		libdbix-class-perl=0.082841-1 \
+		ca-certificates=20211016 \
+		cpanminus=1.7045-1 \
+		git=1:2.34.1-1ubuntu1.4 \
+		libarray-utils-perl=0.5-2 \
+		libcanary-stability-perl=2006-2 \
+		libcapture-tiny-perl=0.48-1 \
+		libclass-accessor-lite-perl=0.08-1.1 \
+		libclone-perl=0.45-1build3 \
+		libcommon-sense-perl=3.75-2build1 \
+		libcpanel-json-xs-perl=4.27-1build1 \
+		libcrypt-ssleay-perl=0.73.06-1build6 \
+		libdata-dump-perl=1.25-1 \
+		libdatetime-format-strptime-perl=1.7900-1 \
+		#libdbd-mysql-perl=4.050-5 \ # if desired to use a full database
+		libdbd-sqlite3-perl=1.70-3build1 \
 		libdbix-class-inflatecolumn-serializer-perl=0.09-1 \
+		libdbix-class-perl=0.082842-3 \
 		libdbix-dbschema-perl=0.45-1 \
-		libdevel-cover-perl=1.33-1build1 \
-		libexception-class-perl=1.44-1 \
-		libjson-perl=4.02000-2 \
-		libnet-ssleay-perl=1.88-2ubuntu1 \
-		libsql-translator-perl=1.60-1 \
-		libssl-dev=1.1.1f-1ubuntu2.5 \
+		libdevel-cover-perl=1.36-2build2 \
+		libc6-dev=2.35-0ubuntu3.1 \
+		libexception-class-perl=1.45-1 \
+		libextutils-config-perl=0.008-2 \
+		libextutils-helpers-perl=0.026-1 \
+		libextutils-installpaths-perl=0.012-1.1 \
+		libfurl-perl=3.14-2 \
+		libhttp-parser-xs-perl=0.17-2build1 \
+		libimporter-perl=0.026-1 \
+		libio-socket-ssl-perl=2.074-2 \
+		libjson-perl=4.04000-1 \
+		libjson-xs-perl=4.030-1build3 \
+		libmodule-build-tiny-perl=0.039-1.1 \
+		libmojolicious-perl=9.22+dfsg-1 \
+		libmojolicious-plugin-authentication-perl=1.37-1 \
+		libnet-ssleay-perl=1.92-1build2 \
+		libsql-translator-perl=1.62-1 \
+		libssl-dev=3.0.2-0ubuntu1.6 \
 		libtest-exception-perl=0.43-1 \
-		libtest-harness-perl=3.42-2 \
-		libtext-csv-perl=2.00-1 \
-		libtry-tiny-perl=0.30-1 \
-		libyaml-libyaml-perl=0.81+repack-1 \
-		# mariadb-server=1:10.3.31-0ubuntu0.20.04.1 \ # if desired to use a full database
-		openssl=1.1.1f-1ubuntu2.5 && \
+		libtext-csv-perl=2.01-1 \
+		libtry-tiny-perl=0.31-1 \
+		libtypes-serialiser-perl=1.01-1 \
+		libyaml-libyaml-perl=0.83+ds-1build1 \
+		make=4.3-4.1build1 \
+		#mariadb-server=1:10.6.7-2ubuntu1.1 \ # if desired to use a full database
+		openssl=3.0.2-0ubuntu1.6 && \
 	rm -rf /var/lib/apt/lists/* && \
 	cpanm --notest \
 		DBIx::Class::DynamicSubclass \
-		Mojolicious \
-		Mojolicious::Plugin::NotYAMLConfig \
 		Mojolicious::Plugin::DBIC \
-		Mojolicious::Plugin::Authentication \
+		Mojolicious::Plugin::NotYAMLConfig \
 		Devel::Cover::Report::Codecov
 
 ENTRYPOINT ["/bin/bash"]

--- a/lib/DB/Schema/Result/Attempt.pm
+++ b/lib/DB/Schema/Result/Attempt.pm
@@ -59,7 +59,7 @@ Note: a problem should have only one of a library_id, problem_path or problem_po
 
 __PACKAGE__->table('attempt');
 
-__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
+__PACKAGE__->load_components(qw/InflateColumn::Serializer Core/);
 
 __PACKAGE__->add_columns(
 	attempt_id => {

--- a/lib/DB/Schema/Result/CourseSettings.pm
+++ b/lib/DB/Schema/Result/CourseSettings.pm
@@ -49,7 +49,7 @@ C<email>: a JSON object that stores email settings
 
 __PACKAGE__->table('course_settings');
 
-__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
+__PACKAGE__->load_components(qw/InflateColumn::Serializer Core/);
 
 __PACKAGE__->add_columns(
 	course_settings_id => {

--- a/lib/DB/Schema/Result/CourseUser.pm
+++ b/lib/DB/Schema/Result/CourseUser.pm
@@ -88,7 +88,7 @@ C<showOldAnswers>: whether or not the user shows old answer (boolean)
 
 __PACKAGE__->table('course_user');
 
-__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
+__PACKAGE__->load_components(qw/InflateColumn::Serializer Core/);
 
 __PACKAGE__->add_columns(
 	course_user_id => {

--- a/lib/DB/Schema/Result/PoolProblem.pm
+++ b/lib/DB/Schema/Result/PoolProblem.pm
@@ -48,7 +48,7 @@ Note: the C<params> can only have one of the two fields
 
 __PACKAGE__->table('pool_problem');
 
-__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
+__PACKAGE__->load_components(qw/InflateColumn::Serializer Core/);
 
 __PACKAGE__->add_columns(
 	pool_problem_id => {

--- a/lib/DB/Schema/Result/ProblemSet.pm
+++ b/lib/DB/Schema/Result/ProblemSet.pm
@@ -71,11 +71,9 @@ L<DB::Schema::Result::ProblemSet::ReviewSet> which gives properties common to re
 
 =cut
 
-__PACKAGE__->load_components(qw/DynamicSubclass Core/);
-
 __PACKAGE__->table('problem_set');
 
-__PACKAGE__->load_components(qw/DynamicSubclass Core/, qw/InflateColumn::Serializer Core/);
+__PACKAGE__->load_components(qw/DynamicSubclass Core InflateColumn::Serializer InflateColumn::Boolean Core/);
 
 __PACKAGE__->add_columns(
 	set_id => {

--- a/lib/DB/Schema/Result/SetProblem.pm
+++ b/lib/DB/Schema/Result/SetProblem.pm
@@ -65,7 +65,7 @@ Note: a problem should have only one of a library_id, problem_path or problem_po
 
 __PACKAGE__->table('set_problem');
 
-__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
+__PACKAGE__->load_components(qw/InflateColumn::Serializer Core/);
 
 __PACKAGE__->add_columns(
 	set_problem_id => {

--- a/lib/DB/Schema/Result/UserProblem.pm
+++ b/lib/DB/Schema/Result/UserProblem.pm
@@ -15,7 +15,7 @@ use base qw/DBIx::Class::Core DB::Validation/;
 
 __PACKAGE__->table('user_problem');
 
-__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
+__PACKAGE__->load_components(qw/InflateColumn::Serializer Core/);
 
 __PACKAGE__->add_columns(
 	user_problem_id => {

--- a/lib/DB/Schema/Result/UserSet.pm
+++ b/lib/DB/Schema/Result/UserSet.pm
@@ -58,7 +58,7 @@ types have different params fields.
 
 __PACKAGE__->table('user_set');
 
-__PACKAGE__->load_components('InflateColumn::Serializer', 'Core');
+__PACKAGE__->load_components(qw/InflateColumn::Serializer InflateColumn::Boolean Core/);
 
 __PACKAGE__->add_columns(
 	user_set_id => {

--- a/t/db/001_courses.t
+++ b/t/db/001_courses.t
@@ -18,6 +18,7 @@ use Test::More;
 use Test::Exception;
 use YAML::XS qw/LoadFile/;
 use DateTime::Format::Strptime;
+use Mojo::JSON qw/true false/;
 
 use DB::Schema;
 
@@ -90,7 +91,7 @@ throws_ok {
 # Add a course
 my $new_course_params = {
 	course_name  => 'Geometry',
-	visible      => 1,
+	visible      => true,
 	course_dates => {}
 };
 

--- a/t/db/004_course_users.t
+++ b/t/db/004_course_users.t
@@ -42,7 +42,7 @@ my $user_rs = $schema->resultset('User');
 # Get a list of users from the CSV file
 my @students = loadCSV("$main::ww3_dir/t/db/sample_data/students.csv");
 for my $student (@students) {
-	$student->{is_admin}           = 0;
+	$student->{is_admin}           = false;
 	$student->{course_user_params} = $student->{params};
 	delete $student->{params};
 }
@@ -124,7 +124,7 @@ my $user_params = {
 	last_name  => 'Quimby',
 	email      => 'mayor_joe@springfield.gov',
 	student_id => '12345',
-	is_admin   => 0
+	is_admin   => false
 };
 
 my $course_user_params = {

--- a/t/db/006_quizzes.t
+++ b/t/db/006_quizzes.t
@@ -45,7 +45,13 @@ my $user_rs        = $schema->resultset('User');
 
 my @all_problem_sets;
 
-my @quizzes = loadCSV("$main::ww3_dir/t/db/sample_data/quizzes.csv");
+my @quizzes = loadCSV(
+	"$main::ww3_dir/t/db/sample_data/quizzes.csv",
+	{
+		boolean_fields       => ['set_visible'],
+		param_boolean_fields => ['timed']
+	}
+);
 for my $quiz (@quizzes) {
 	$quiz->{set_type} = 'QUIZ';
 }
@@ -248,7 +254,7 @@ my $updated_quiz   = $problem_set_rs->updateProblemSet(
 	params => $updated_params
 );
 
-$new_quiz->{set_visible} = 0;
+$new_quiz->{set_visible} = false;
 $new_quiz->{set_params}  = {};
 removeIDs($updated_quiz);
 is_deeply($new_quiz, $updated_quiz, 'updateQuiz: successfully update the quiz');

--- a/t/mojolicious/001_login.t
+++ b/t/mojolicious/001_login.t
@@ -5,8 +5,7 @@ use Mojo::Base -strict;
 use Test::More;
 use Test::Mojo;
 use YAML::XS qw/LoadFile/;
-
-use YAML::XS qw/LoadFile/;
+use Mojo::JSON qw/true false/;
 
 BEGIN {
 	use File::Basename qw/dirname/;
@@ -36,11 +35,11 @@ $t->post_ok('/webwork3/api/login')->status_is(500, 'error status')->content_type
 $t->post_ok('/webwork3/api/login' => json => { username => 'lisa', password => 'lisa' })->status_is(200)
 	->content_type_is('application/json;charset=UTF-8')->json_is(
 		'' => {
-			logged_in => 1,
+			logged_in => true,
 			user      => {
 				email      => 'lisa@google.com',
 				first_name => 'Lisa',
-				is_admin   => 0,
+				is_admin   => false,
 				last_name  => 'Simpson',
 				student_id => '23',
 				user_id    => 3,
@@ -53,7 +52,7 @@ $t->post_ok('/webwork3/api/login' => json => { username => 'lisa', password => '
 # Test logout
 $t->post_ok('/webwork3/api/logout')->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is(
 	'' => {
-		logged_in => 0,
+		logged_in => false,
 		message   => 'Successfully logged out.'
 	},
 	'logout'
@@ -63,7 +62,7 @@ $t->post_ok('/webwork3/api/logout')->status_is(200)->content_type_is('applicatio
 $t->post_ok('/webwork3/api/login' => json => { username => 'lisa', password => 'wrong_password' })->status_is(200)
 	->content_type_is('application/json;charset=UTF-8')->json_is(
 		'' => {
-			logged_in => 0,
+			logged_in => false,
 			message   => 'Incorrect username or password.'
 		},
 		'invalid credentials'

--- a/t/mojolicious/002_courses.t
+++ b/t/mojolicious/002_courses.t
@@ -28,14 +28,14 @@ my $t = Test::Mojo->new(WeBWorK3 => $config);
 
 # Authenticate with the admin user.
 $t->post_ok('/webwork3/api/login' => json => { username => 'admin', password => 'admin' })->status_is(200)
-	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)->json_is('/user/user_id' => 1)
-	->json_is('/user/is_admin' => 1);
+	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => true)->json_is('/user/user_id' => 1)
+	->json_is('/user/is_admin' => true);
 
 $t->get_ok('/webwork3/api/courses')->content_type_is('application/json;charset=UTF-8')
-	->json_is('/0/course_name' => 'Precalculus')->json_is('/0/visible' => 1);
+	->json_is('/0/course_name' => 'Precalculus')->json_is('/0/visible' => true);
 
 $t->get_ok('/webwork3/api/courses/1')->content_type_is('application/json;charset=UTF-8')
-	->json_is('/course_name' => 'Precalculus')->json_is('/visible' => 1);
+	->json_is('/course_name' => 'Precalculus')->json_is('/visible' => true);
 
 # Add a new course
 my $new_course = {
@@ -124,8 +124,8 @@ $t->get_ok('/webwork3/api/courses/4/settings')->status_is(200)->content_type_is(
 $t->post_ok('/webwork3/api/courses' => json => $new_course)->status_is(403)->json_is('/has_permission' => 0);
 
 $t->put_ok('/webwork3/api/courses/4' => json => { course_name => 'XXX' })->status_is(403)
-	->json_is('/has_permission' => false);
+	->json_is('/has_permission' => 0);
 
-$t->delete_ok('/webwork3/api/courses/4')->status_is(403)->json_is('/has_permission' => false);
+$t->delete_ok('/webwork3/api/courses/4')->status_is(403)->json_is('/has_permission' => 0);
 
 done_testing;

--- a/t/mojolicious/003_users.t
+++ b/t/mojolicious/003_users.t
@@ -38,8 +38,8 @@ my $t = Test::Mojo->new(WeBWorK3 => $config);
 # Test all of the user routes with an admin user.
 
 $t->post_ok('/webwork3/api/login' => json => { username => 'admin', password => 'admin' })->status_is(200)
-	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)->json_is('/user/user_id' => 1)
-	->json_is('/user/is_admin' => 1);
+	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => true)->json_is('/user/user_id' => 1)
+	->json_is('/user/is_admin' => true);
 
 my @all_users = $schema->resultset('User')->getAllGlobalUsers();
 
@@ -56,7 +56,7 @@ my $new_user = {
 	last_name  => 'Simpson',
 	username   => 'maggie',
 	student_id => '1234123423',
-	is_admin   => 0
+	is_admin   => false
 };
 
 $t->post_ok('/webwork3/api/users' => json => $new_user)->status_is(200)
@@ -158,10 +158,10 @@ $t->delete_ok("/webwork3/api/users/$another_new_user_id")->status_is(200)
 # Test that a non-admin user cannot access all of the routes
 # Logout the admin user and relogin as a non-admin.
 
-$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => 0);
+$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => false);
 $t->post_ok('/webwork3/api/login' => json => { username => 'lisa', password => 'lisa' })->status_is(200)
-	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
-	->json_is('/user/username' => 'lisa')->json_is('/user/is_admin' => 0);
+	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => true)
+	->json_is('/user/username' => 'lisa')->json_is('/user/is_admin' => false);
 
 $t->get_ok('/webwork3/api/users')->content_type_is('application/json;charset=UTF-8')->status_is(403)
 	->json_is('/has_permission' => 0);
@@ -182,7 +182,7 @@ $t->delete_ok('/webwork3/api/users/1')->content_type_is('application/json;charse
 $t->get_ok('/webwork3/api/users/3/courses')->status_is(200)->content_type_is('application/json;charset=UTF-8');
 
 # Relogin as the admin and delete the added users
-$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => 0);
+$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => false);
 $t->post_ok('/webwork3/api/login' => json => { username => 'admin', password => 'admin' })->status_is(200);
 
 # The following routes test that global users can be handled by an instructor in the course

--- a/t/mojolicious/008_problems.t
+++ b/t/mojolicious/008_problems.t
@@ -41,8 +41,8 @@ my $t = Test::Mojo->new(WeBWorK3 => $config);
 
 # First run tests as logged in as an instructor
 $t->post_ok('/webwork3/api/login' => json => { username => 'lisa', password => 'lisa' })->status_is(200)
-	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
-	->json_is('/user/username' => 'lisa')->json_is('/user/is_admin' => 0);
+	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => true)
+	->json_is('/user/username' => 'lisa')->json_is('/user/is_admin' => false);
 
 # Load all problems from the CVS files.
 my @problems_from_csv = loadCSV(
@@ -111,10 +111,10 @@ $t->put_ok(
 	->json_is('/problem_number' => $new_problem->{problem_number})->json_is('/problem_params/weight' => 3);
 
 # Make sure that a student cannot access the global problem routes
-$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => 0);
+$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => false);
 $t->post_ok('/webwork3/api/login' => json => { username => 'ralph', password => 'ralph' })->status_is(200)
-	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
-	->json_is('/user/username' => 'ralph')->json_is('/user/is_admin' => 0);
+	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => true)
+	->json_is('/user/username' => 'ralph')->json_is('/user/is_admin' => false);
 
 my $logged_in_user = $t->tx->res->json('/user');
 
@@ -157,10 +157,10 @@ $t->delete_ok("/webwork3/api/courses/4/sets/$hw1->{set_id}/problems/$new_problem
 
 # Make sure that a student not enrolled in the course has access to getting global problems
 # for that course.
-$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => 0);
+$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => false);
 $t->post_ok('/webwork3/api/login' => json => { username => 'ned', password => 'ned' })->status_is(200)
-	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)->json_is('/user/username' => 'ned')
-	->json_is('/user/is_admin' => 0);
+	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => true)
+	->json_is('/user/username' => 'ned')->json_is('/user/is_admin' => false);
 
 $logged_in_user = $t->tx->res->json('/user');
 
@@ -174,7 +174,7 @@ is(scalar(grep { $_->{course_name} eq 'Arithmetic' } @$user_courses), 0, 'The us
 $t->get_ok('/webwork3/api/courses/4/problems')->status_is(403)->content_type_is('application/json;charset=UTF-8');
 
 # Finally, delete the new problem to restore the db to it's pretest state.
-$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => 0);
+$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => false);
 $t->post_ok('/webwork3/api/login' => json => { username => 'admin', password => 'admin' })->status_is(200);
 
 $t->delete_ok("/webwork3/api/courses/4/sets/$hw1->{set_id}/problems/$new_problem->{set_problem_id}")->status_is(200)

--- a/t/mojolicious/009_user_problems.t
+++ b/t/mojolicious/009_user_problems.t
@@ -41,8 +41,8 @@ my $t = Test::Mojo->new(WeBWorK3 => $config);
 
 # First run tests as logged in as an instructor
 $t->post_ok('/webwork3/api/login' => json => { username => 'lisa', password => 'lisa' })->status_is(200)
-	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => 1)
-	->json_is('/user/username' => 'lisa')->json_is('/user/is_admin' => 0);
+	->content_type_is('application/json;charset=UTF-8')->json_is('/logged_in' => true)
+	->json_is('/user/username' => 'lisa')->json_is('/user/is_admin' => false);
 
 # Load all problems from the CVS files.
 my @problems_from_csv = loadCSV(
@@ -174,7 +174,7 @@ $t->put_ok(
 	->json_is('/seed' => 789);
 
 # Check that a student has the correct access
-$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => 0);
+$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => false);
 $t->post_ok('/webwork3/api/login' => json => { username => 'ralph', password => 'ralph' })->status_is(200);
 
 # get all of ralph's problems
@@ -208,7 +208,7 @@ $t->delete_ok(
 	->status_is(403);
 
 # Make sure that a user that is in the course, cannot get or update a user problem that is not one's own.
-$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => 0);
+$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => false);
 $t->post_ok('/webwork3/api/login' => json => { username => 'moe', password => 'moe' })->status_is(200);
 
 # Check that moe is in the course
@@ -233,7 +233,7 @@ $t->put_ok(
 		=> json => { status => 0.5 })->status_is(403);
 
 # Switch back to the instructor and delete the user problem
-$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => 0);
+$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => false);
 $t->post_ok('/webwork3/api/login' => json => { username => 'lisa', password => 'lisa' })->status_is(200);
 
 $t->delete_ok(

--- a/t/mojolicious/010_problem_pools.t
+++ b/t/mojolicious/010_problem_pools.t
@@ -150,7 +150,7 @@ $t->put_ok(
 )->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/params/library_id' => 8932);
 
 # Make sure that students don't have access to Problem Pools
-$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => 0);
+$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => false);
 $t->post_ok('/webwork3/api/login' => json => { username => 'ralph', password => 'ralph' })->status_is(200);
 
 $t->get_ok('/webwork3/api/courses/4/pools')->status_is(403);
@@ -189,7 +189,7 @@ $t->delete_ok(
 )->status_is(403);
 
 # Cleanup.  Log back in as the instructor and delete added pool and problem
-$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => 0);
+$t->post_ok('/webwork3/api/logout')->status_is(200)->json_is('/logged_in' => false);
 $t->post_ok('/webwork3/api/login' => json => { username => 'lisa', password => 'lisa' })->status_is(200);
 
 # Delete the pool problem.


### PR DESCRIPTION
This just uses the ubuntu 22.04 runner, and installs the webwork3 dependencies directly, and then runs the unit tests.  It actually doesn't take much longer to do this than to use the prebuilt docker image.

This is one way to solve the issue of the dependence on a docker image that does not belong to the openwebwork project.

There is one issue though.  Several of the tests were failing with this new approach.  Looking closely at the tests that were failing, I realized that those tests should be failing.  All of the tests that were failing were boolean values compared to numerical values.  Those tests have been fixed in this pull request.  However, the issue is that for some reason the fixed tests were passing for us when we run the tests on our local machines and they were passing in the previous docker image approach.  We need to figure this out, so that we don't need to wait until the workflow has run to see what needs to be fixed.

The dockerfile used for the previous workflow image has also been updated for new Ubuntu package versions.  Also the dependencies of Devel::Cover::Report::Codecove that are available in the Ubuntu repositories are installed via those packages.  This speeds up the build some.  Ubuntu packages install faster than building from cpan source via cpanm.

Note there was an instance in lib/DB/Schema/Result/ProblemSet.pm of a boolean column, and so that package should load the InflateColumn::Boolean class.  Also, all of the `__PACKAGE__->load_components` calls were made uniform.