### PR TITLE
Fix the Mojo::Home usage if the app is run from outside the project root

### DIFF
--- a/lib/WeBWorK3/Controller/Logger.pm
+++ b/lib/WeBWorK3/Controller/Logger.pm
@@ -7,7 +7,7 @@ use Mojo::Home;
 use Mojo::Log;
 use JSON qw/decode_json/;
 
-my $clientLogFile = Mojo::Log->new(path => Mojo::Home->new->detect->child('logs', 'clientLog.log'));
+my $clientLogFile = Mojo::Log->new(path => Mojo::Home->new->detect('WeBWorK3')->child('logs', 'clientLog.log'));
 
 sub clientLog ($c) {
 	my $rawJSON  = $c->req->body;

--- a/lib/WeBWorK3/Utils/Settings.pm
+++ b/lib/WeBWorK3/Utils/Settings.pm
@@ -32,7 +32,7 @@ load the default settings from the conf/course_settings.yaml file
 =cut
 
 sub getDefaultCourseSettings () {
-	return LoadFile(Mojo::Home->new->detect->child('conf', 'course_defaults.yml'));
+	return LoadFile(Mojo::Home->new->detect('WeBWorK3')->child('conf', 'course_defaults.yml'));
 }
 
 my @course_setting_categories = qw/email optional general permissions problem problem_set/;


### PR DESCRIPTION
In order for Mojo::Home detect to return the correct project root directory in all cases the application class needs to be passed to the detect method.